### PR TITLE
fix: setup issues

### DIFF
--- a/django/chat/models.py
+++ b/django/chat/models.py
@@ -26,6 +26,8 @@ DEFAULT_MODE = "chat"
 
 
 def create_chat_data_source(user):
+    if not user.personal_library:
+        user.create_personal_library()
     return DataSource.objects.create(
         name=f"Chat {timezone.now().strftime('%Y-%m-%d %H:%M:%S')}",
         library=user.personal_library,

--- a/django/chat/views.py
+++ b/django/chat/views.py
@@ -295,8 +295,6 @@ def chat(request, chat_id):
     if not chat.options:
         chat.options = ChatOptions.objects.from_defaults(user=chat.user)
         chat.save()
-    if not request.user.personal_library:
-        request.user.create_personal_library()
     if not chat.data_source:
         chat.data_source = create_chat_data_source(request.user)
         chat.save()

--- a/django/initial_setup.sh
+++ b/django/initial_setup.sh
@@ -1,16 +1,16 @@
 #!/bin/sh
 
 echo "Running database migrations..."
-python manage.py migrate || { echo "Error: Migrate failed"; exit 1; }
+{ python manage.py migrate || { echo "Error: Migrate failed"; exit 1; } }
 
 echo "Resetting app data..."
-python manage.py reset_app_data apps terms groups library_mini security_labels || { echo "Error: Reset app data failed"; exit 1; }
+{ python manage.py reset_app_data apps terms groups library_mini security_labels cost_types || { echo "Error: Reset app data failed"; exit 1; } }
 
 echo "Loading corporate library..."
-python manage.py load_corporate_library --force || { echo "Error: Load corporate library failed"; exit 1; }
+{ python manage.py load_corporate_library --force || { echo "Error: Load corporate library failed"; exit 1; } }
 
 echo "Loading laws XML..."
-python manage.py load_laws_xml --reset --small || { echo "Error: Load laws XML failed"; exit 1; }
+{ python manage.py load_laws_xml --reset --small || { echo "Error: Load laws XML failed"; exit 1; } }
 
 echo "Cleaning static files..."
 if [ -d "staticfiles" ]; then
@@ -21,10 +21,10 @@ else
 fi
 
 echo "Collecting static files..."
-python manage.py collectstatic --noinput || { echo "Error: Collect static files failed"; exit 1; }
+{ python manage.py collectstatic --noinput || { echo "Error: Collect static files failed"; exit 1; } }
 
 echo "Syncing users..."
-python manage.py sync_users || { echo "Error: Sync users failed"; exit 1; }
+{ python manage.py sync_users || { echo "Error: Sync users failed"; exit 1; } }
 
 # Check if OTTO_ADMIN is provided
 if [ -n "$OTTO_ADMIN" ]; then


### PR DESCRIPTION
Because users in setup script were being created with `User.objects.aupdate_or_create` rather than `User.objects.create`, the setup code for creating a user personal library was not run.

I moved the code to create the personal library closer to where the error was occurring, so it doesn't rely on using the `User.objects.create` method.

There were also two other issues, unrelated but worth fixing at the same time:
1. Braces syntax in `initial_setup.sh`
2. Not loading `cost_types` in `initial_setup.sh`.