### PR TITLE
ops: 4gb ram for celery worker pod

### DIFF
--- a/setup/k8s/celery.yaml
+++ b/setup/k8s/celery.yaml
@@ -94,10 +94,10 @@ spec:
           resources:
             requests:
               cpu: "1"
-              memory: "2Gi"
+              memory: "4Gi"
             limits:
               cpu: "1"
-              memory: "2Gi"
+              memory: "4Gi"
           volumeMounts:
             - name: secrets  # Mounts secrets from Azure Key Vault
               mountPath: "/mnt/secrets-store"


### PR DESCRIPTION
**purpose**: resolve OOMKilled restarts in k8s

already deployed in sandbox. since we have 2 nodes now, there is more than enough memory to go around

if OOM errors persist, we can continue tuning this.