### PR TITLE
fix: dragging file into chat / uploading file clears the prompt

### DIFF
--- a/django/chat/static/chat/js/scripts.js
+++ b/django/chat/static/chat/js/scripts.js
@@ -137,6 +137,8 @@ document.addEventListener("DOMContentLoaded", function () {
 // On prompt form submit...
 document.addEventListener("htmx:afterSwap", function (event) {
   if (event.target.id != "messages-container") return;
+  if (event.detail.pathInfo.requestPath.includes('upload'))
+    return;
   if (document.querySelector("#no-messages-placeholder") !== null) {
     document.querySelector("#no-messages-placeholder").remove();
   }


### PR DESCRIPTION
Not sure if its the most elegant way of doing it, but it seems to work.