### PR TITLE
fix: prevent special chars in vectordb password

### DIFF
--- a/django/otto/settings.py
+++ b/django/otto/settings.py
@@ -269,7 +269,6 @@ if os.environ.get("DJANGODB_ENGINE") is not None:
         "ENGINE": os.environ.get("DJANGODB_ENGINE"),
         "NAME": os.environ.get("DJANGODB_NAME"),
         "USER": os.environ.get("DJANGODB_USER"),
-        # CosmosDB can't have the password quoted; it seems to handle this natively. TODO: Investigate to understand better
         "PASSWORD": os.environ.get("DJANGODB_PASSWORD", ""),
         "HOST": os.environ.get("DJANGODB_HOST"),
     }
@@ -284,8 +283,7 @@ if os.environ.get("VECTORDB_ENGINE") is not None:
         "ENGINE": os.environ.get("VECTORDB_ENGINE"),
         "NAME": os.environ.get("VECTORDB_NAME"),
         "USER": os.environ.get("VECTORDB_USER"),
-        # Passwords for Postgres need to be quoted to handle special characters
-        "PASSWORD": quote(os.environ.get("VECTORDB_PASSWORD", "")),
+        "PASSWORD": os.environ.get("VECTORDB_PASSWORD", ""),
         "HOST": os.environ.get("VECTORDB_HOST"),
     }
 

--- a/setup/terraform/modules/keyvault/main.tf
+++ b/setup/terraform/modules/keyvault/main.tf
@@ -58,7 +58,7 @@ resource "azurerm_key_vault_secret" "entra_client_secret" {
 
 resource "random_password" "vectordb_password" {
   length  = 16
-  special = true
+  special = false
 }
 
 resource "azurerm_key_vault_secret" "vectordb_password" {


### PR DESCRIPTION
Solves an intermittent bug where Django connections cursor to the vectordb gives a password error.
Quoting the password in Django works for LlamaIndex, but not connections cursor, which does not unquote.

Simple solution is to remove the quoting and don't use special characters when generating the password.