### PR TITLE
fix: delete or create library bug (update sidebar)

### DIFF
--- a/django/chat/templates/chat/components/chat_options_accordion.html
+++ b/django/chat/templates/chat/components/chat_options_accordion.html
@@ -13,6 +13,9 @@
       handleModeChange(mode);
       setTimeout(updateQaSourceForms, 100);
     }
+    if ("{{ trigger_library_change }}" === "true") {
+      document.getElementById("id_qa_library").dispatchEvent(new Event('change'));
+    }
   })();
 
   updateQaSourceForms();

--- a/django/chat/templates/chat/components/options_submenu.html
+++ b/django/chat/templates/chat/components/options_submenu.html
@@ -4,14 +4,14 @@
             type="button"
             data-bs-toggle="collapse"
             data-bs-target="#options-accordion-{{ options_section_id }}"
-            aria-expanded="true"
+            aria-expanded="{% if options_form.mode.value == options_section_id %}true{% else %}false{% endif %}"
             aria-controls="options-accordion-{{ options_section_id }}"
             onclick="handleModeChange('{{ options_section_id }}', this)">
       {% block accordion_title %}{% endblock %}
     </button>
   </h5>
   <div id="options-accordion-{{ options_section_id }}"
-       class="accordion-collapse collapse{% if swap %} show{% endif %}"
+       class="accordion-collapse collapse{% if swap or options_form.mode.value == options_section_id %} show{% endif %}"
        data-bs-parent="#options-accordion"
        {% if swap %}hx-swap-oob="true" hx-ext="morph"{% endif %}>
     <div class="accordion-body bg-light p-0 pb-2">

--- a/django/chat/urls.py
+++ b/django/chat/urls.py
@@ -56,6 +56,11 @@ urlpatterns = [
         name="chat_options",
     ),
     path(
+        "id/<str:chat_id>/options/set_qa_library/<int:library_id>",
+        views.update_from_librarian,
+        name="update_from_librarian",
+    ),
+    path(
         "id/<str:chat_id>/set_security_label/<str:security_label_id>",
         views.set_security_label,
         name="set_security_label",

--- a/django/chat/urls.py
+++ b/django/chat/urls.py
@@ -57,7 +57,7 @@ urlpatterns = [
     ),
     path(
         "id/<str:chat_id>/options/set_qa_library/<int:library_id>",
-        views.update_from_librarian,
+        views.update_qa_options_from_librarian,
         name="update_from_librarian",
     ),
     path(

--- a/django/chat/views.py
+++ b/django/chat/views.py
@@ -670,7 +670,7 @@ def message_sources(request, message_id):
 
 
 @permission_required("chat.access_chat", objectgetter(Chat, "chat_id"))
-def update_from_librarian(request, chat_id, library_id):
+def update_qa_options_from_librarian(request, chat_id, library_id):
     # (See librarian/scripts.js)
     chat = Chat.objects.get(id=chat_id)
     original_library = chat.options.qa_library

--- a/django/librarian/static/librarian/scripts.js
+++ b/django/librarian/static/librarian/scripts.js
@@ -6,23 +6,24 @@ function toggleWarning(public_checkbox) {
   }
 }
 
-let librarianModalCloseHandler = null;
-
-updateLibrarianModalOnClose = (library_id) => {
-  const modalEl = document.getElementById('editLibrariesModal');
-  modalEl.removeEventListener('hidden.bs.modal', librarianModalCloseHandler);
-  librarianModalCloseHandler = event => {
-    // Stop polling on element id="libraryModalPoller"
-    // by replacing it with empty div
-    const poller = document.getElementById('libraryModalPoller');
-    const newPoller = document.createElement('div');
-    newPoller.id = 'libraryModalPoller';
-    poller.parentNode.replaceChild(newPoller, poller);
-    // Update the QA library select
-    htmx.ajax('GET', `/chat/id/${chat_id}/options/set_qa_library/${library_id}`, {target: '#options-accordion'});
-  };
-  modalEl.addEventListener('hidden.bs.modal', librarianModalCloseHandler);
+let librarianModalCloseHandler = event => {
+  // Stop polling on element id="libraryModalPoller"
+  // by replacing it with empty div
+  const poller = document.getElementById('libraryModalPoller');
+  const newPoller = document.createElement('div');
+  newPoller.id = 'libraryModalPoller';
+  poller.parentNode.replaceChild(newPoller, poller);
+  // Fake library ID which won't exist. If passed through, this will reset the QA library to the default.
+  let library_id = 99999999999999999999;
+  const selected_library_li = document.querySelector("#librarian-libraries li.list-group-item[aria-selected='true']");
+  if (selected_library_li) {
+    library_id = selected_library_li.getAttribute('data-library-id');
+  }
+  // Update the QA library select
+  htmx.ajax('GET', `/chat/id/${chat_id}/options/set_qa_library/${library_id}`, {target: '#options-accordion'});
 };
+const modalEl = document.getElementById('editLibrariesModal');
+modalEl.addEventListener('hidden.bs.modal', librarianModalCloseHandler);
 
 const MAX_FILES_PER_DATA_SOURCE = 100;
 const MAX_SIZE_MB = 300;

--- a/django/librarian/static/librarian/scripts.js
+++ b/django/librarian/static/librarian/scripts.js
@@ -19,12 +19,7 @@ updateLibrarianModalOnClose = (library_id) => {
     newPoller.id = 'libraryModalPoller';
     poller.parentNode.replaceChild(newPoller, poller);
     // Update the QA library select
-    const qa_library_select = document.getElementById("id_qa_library");
-    // Only update if the value is different (allow type coercion)
-    if (qa_library_select.value != library_id) {
-      qa_library_select.value = library_id;
-      qa_library_select.dispatchEvent(new Event('change'));
-    }
+    htmx.ajax('GET', `/chat/id/${chat_id}/options/set_qa_library/${library_id}`, {target: '#options-accordion'});
   };
   modalEl.addEventListener('hidden.bs.modal', librarianModalCloseHandler);
 };

--- a/django/librarian/templates/librarian/components/list_item.html
+++ b/django/librarian/templates/librarian/components/list_item.html
@@ -6,7 +6,7 @@
     tabindex="0"
     onkeypress="if(event.key === 'Enter') { this.click(); }"
     {% if item == selected_item %}aria-selected="true"{% endif %}
-    {% if item_type == "library" %}onclick="updateLibrarianModalOnClose({{ item.id }})"{% endif %}
+    {% if item_type == "library" %}data-library-id="{{ item.id }}"{% endif %}
     {% if not item.temp %} hx-get="{% get_librarian_modal_url item_type item.id %}" {% endif %}>
   {% include "librarian/components/list_item_inner.html" %}
 </li>

--- a/django/librarian/templates/librarian/forms/library.html
+++ b/django/librarian/templates/librarian/forms/library.html
@@ -85,6 +85,3 @@
     {% endif %}
   </div>
 </form>
-{# Quirk: The JS below often doesn't run when content swapped in with HTMX morph #}
-{# So we also call the updateLibrarianModalOnClose function from list_item.html #}
-{% if form.instance.id %}<script>updateLibrarianModalOnClose({{ form.instance.id }});</script>{% endif %}

--- a/django/tests/chat/test_chat_views.py
+++ b/django/tests/chat/test_chat_views.py
@@ -342,6 +342,7 @@ def test_done_upload(client, all_apps_user):
 # TODO: Test chunk_upload (somewhat difficult)
 # See tests/otto/test_cleanup.py for a partial test of chunk upload
 
+
 # Test download_file view
 @pytest.mark.django_db
 def test_download_file(client, all_apps_user):
@@ -842,3 +843,52 @@ def test_summarize_qa_response(client, all_apps_user):
     )
     response = client.get(reverse("chat:chat_response", args=[response_message.id]))
     assert response.status_code == 200
+
+
+@pytest.mark.django_db
+def test_update_qa_options_from_librarian(client, all_apps_user):
+    from librarian.models import DataSource, Document, Library
+
+    user = all_apps_user()
+    client.force_login(user)
+    chat = Chat.objects.create(user=user)
+    library = user.personal_library
+    response = client.get(
+        reverse("chat:update_from_librarian", args=[chat.id, library.id])
+    )
+    assert response.status_code == 200
+    assert chat.options.qa_library == library
+    assert chat.options.qa_data_sources.count() == 0
+    assert chat.options.qa_documents.count() == 0
+
+    # Try switching to same library. Nothing should change
+    # Let's set a data source and document just to test that they are NOT cleared in this case
+    data_source = DataSource.objects.create(name="Test Data Source")
+    chat.options.qa_data_sources.add(data_source)
+    document = Document.objects.create(title="Test Document")
+    chat.options.qa_documents.add(document)
+    response = client.get(
+        reverse("chat:update_from_librarian", args=[chat.id, library.id])
+    )
+    assert response.status_code == 200
+    assert chat.options.qa_library == library
+    assert chat.options.qa_data_sources.count() == 1
+    assert chat.options.qa_documents.count() == 1
+
+    # Test with a library that doesn't exist
+    response = client.get(reverse("chat:update_from_librarian", args=[chat.id, 999]))
+    assert response.status_code == 200
+    # This should reset to default library and clear data sources and documents
+    assert chat.options.qa_library == Library.objects.get_default_library()
+    assert chat.options.qa_data_sources.count() == 0
+    assert chat.options.qa_documents.count() == 0
+
+    # Test with a library that the user doesn't have access to
+    library = Library.objects.create(name="Test Library 2")
+    response = client.get(
+        reverse("chat:update_from_librarian", args=[chat.id, library.id])
+    )
+    assert response.status_code == 200
+    assert chat.options.qa_library == Library.objects.get_default_library()
+    assert chat.options.qa_data_sources.count() == 0
+    assert chat.options.qa_documents.count() == 0


### PR DESCRIPTION
From original ticket:
> When a library is added or deleted, the changes dont directly appear in the chat window, it gets fixed when i manually refresh the page. Can that process of refreshing be done automatically? it could be confusing for users when creating, editing, or deleting libraries in QnA

To test:

1:
* open librarian modal
* change libraries
* close the modal.
* sidebar should reflect the change

2:
* open modal
* create a library
* close the modal
* sidebar should reflect the change

3:
* open modal
* delete a library
* close the modal
* sidebar should reset to default library

4:
* select a particular data source in the sidebar
* open the modal
* don't do anything
* close the modal
* sidebar should be unchanged