### PR TITLE
fix:  unescaped HTML warning

### DIFF
--- a/django/chat/utils.py
+++ b/django/chat/utils.py
@@ -86,7 +86,6 @@ def llm_response_to_html(llm_response_str):
         "img": ["src", "alt", "title"],
         "a": ["href", "alt", "title"],
         "pre": ["class"],
-        "code": ["class"],
         "span": ["class"],
     }
     clean_html = bleach.clean(raw_html, allowed_tags, allowed_attributes)


### PR DESCRIPTION
BUGS 2921

https://dev.azure.com/BusinessAnalyticsCentre/BAC%20Agile/_workitems/edit/2921

getting the model to write code causes "One of your code blocks includes unescaped HTML" (XSS attack vector)"
