### PR TITLE
feat: view read-only chat from link

### DIFF
--- a/django/.dockerignore
+++ b/django/.dockerignore
@@ -3,3 +3,4 @@ media
 staticfiles
 tests
 __pycache__
+chat/eval

--- a/django/.dockerignore
+++ b/django/.dockerignore
@@ -1,2 +1,5 @@
 .*
 media
+staticfiles
+tests
+__pycache__

--- a/django/chat/templates/chat/chat_readonly.html
+++ b/django/chat/templates/chat/chat_readonly.html
@@ -1,0 +1,45 @@
+{% extends 'base.html' %}
+{% load i18n %}
+{% load static %}
+
+{% block body_classes %}chat{% endblock %}
+
+{% block page_css %}
+  <link rel="stylesheet" href="{% static 'chat/style.css' %}">
+{% endblock %}
+
+{% block page_title %}
+  {% trans "AI assistant - Otto" %}
+{% endblock %}
+
+{% block content_container %}
+  <main id="chat-outer" class="{{ mode }}">
+    <div id="chat-flexbox" class="d-flex justify-content-between mb-3">
+      <div id="chat-container" class="flex-grow-1">
+        <div class="position-fixed end-0 pe-3 pt-1 chat-sidebar-toggle text-muted"
+             style="z-index:1"
+             id="right-sidebar-toggle">
+          <span class="d-xl-inline d-none fw-semibold">{% trans "Read-only" %}</span>
+          <i class="bi bi-file-lock2"
+             style="font-size: 1.5rem;
+                    position: relative;
+                    top: 3px"></i>
+        </div>
+        <div class="container px-5">
+          <div id="messages-container" class="py-3 px-2">{% include 'chat/components/chat_messages.html' %}</div>
+        </div>
+      </div>
+    </div>
+  </main>
+
+  <script src="{% static 'thirdparty/markdown-it.min.js' %}"></script>
+  <script src="{% static 'thirdparty/katex.min.js' %}"></script>
+  <script src="{% static 'thirdparty/markdown-it-katex.js' %}"></script>
+  <script src="{% static 'thirdparty/highlight.js' %}"></script>
+
+  <script src="{% static 'chat/js/scripts.js' %}"></script>
+  <script src="{% static 'librarian/scripts.js' %}"></script>
+
+  <link rel="stylesheet" href="{% static 'thirdparty/css/highlightjs.css' %}">
+  <link rel="stylesheet" href="{% static 'thirdparty/css/katex.min.css' %}">
+{% endblock %}

--- a/django/chat/templates/chat/components/message_actions.html
+++ b/django/chat/templates/chat/components/message_actions.html
@@ -8,41 +8,43 @@
           title='{% trans "Copy" %}'>
     <i class="bi bi-clipboard"></i><i class="bi bi-clipboard-fill"></i>
   </button>
-  {% if message.is_bot %}
-    <button type="button"
-            hx-get="{% url 'chat:thumbs_feedback' message_id=message.id feedback=1 %}"
-            hx-trigger="click"
-            hx-swap="none"
-            class="btn btn-link m-0 ms-1 p-0 text-muted thumb-message-button thumb-up {% if message.feedback == 1 %}clicked{% endif %}"
-            onclick="thumbMessage(this);"
-            title='{% trans "Like" %}'>
-      <i class="bi bi-hand-thumbs-up"></i>
-      <i class="bi bi-hand-thumbs-up-fill"></i>
-    </button>
-    <button type="button"
-            hx-get="{% url 'chat:thumbs_feedback' message_id=message.id feedback=-1 %}"
-            hx-target="#modal-body"
-            hx-trigger="click"
-            class="btn btn-link m-0 ms-1 p-0 text-muted thumb-message-button thumb-down {% if message.feedback == -1 %}clicked{% endif %}"
-            onclick="thumbMessage(this);"
-            title='{% trans "Dislike" %}'>
-      <i class="bi bi-hand-thumbs-down"></i><i class="bi bi-hand-thumbs-down-fill"></i>
-    </button>
-  {% else %}
+  {% if not read_only %}
+    {% if message.is_bot %}
+      <button type="button"
+              hx-get="{% url 'chat:thumbs_feedback' message_id=message.id feedback=1 %}"
+              hx-trigger="click"
+              hx-swap="none"
+              class="btn btn-link m-0 ms-1 p-0 text-muted thumb-message-button thumb-up {% if message.feedback == 1 %}clicked{% endif %}"
+              onclick="thumbMessage(this);"
+              title='{% trans "Like" %}'>
+        <i class="bi bi-hand-thumbs-up"></i>
+        <i class="bi bi-hand-thumbs-up-fill"></i>
+      </button>
+      <button type="button"
+              hx-get="{% url 'chat:thumbs_feedback' message_id=message.id feedback=-1 %}"
+              hx-target="#modal-body"
+              hx-trigger="click"
+              class="btn btn-link m-0 ms-1 p-0 text-muted thumb-message-button thumb-down {% if message.feedback == -1 %}clicked{% endif %}"
+              onclick="thumbMessage(this);"
+              title='{% trans "Dislike" %}'>
+        <i class="bi bi-hand-thumbs-down"></i><i class="bi bi-hand-thumbs-down-fill"></i>
+      </button>
+    {% else %}
+      <button type="button"
+              class="btn btn-link m-0 ms-1 p-0 text-muted"
+              title='{% trans "Edit in new prompt" %}'
+              onclick="copyPromptToTextInput(this, '{{ message.mode }}' )">
+        <i class="bi bi-pencil"></i>
+      </button>
+    {% endif %}
     <button type="button"
             class="btn btn-link m-0 ms-1 p-0 text-muted"
-            title='{% trans "Edit in new prompt" %}'
-            onclick="copyPromptToTextInput(this, '{{ message.mode }}' )">
-      <i class="bi bi-pencil"></i>
+            hx-delete="{% url 'chat:delete_message' message.id %}"
+            hx-target="closest div.message-outer"
+            title="{% trans 'Delete message' %}">
+      <i class="bi bi-trash"></i>
     </button>
   {% endif %}
-  <button type="button"
-          class="btn btn-link m-0 ms-1 p-0 text-muted"
-          hx-delete="{% url 'chat:delete_message' message.id %}"
-          hx-target="closest div.message-outer"
-          title="{% trans 'Delete message' %}">
-    <i class="bi bi-trash"></i>
-  </button>
   {% if "." in message.usd_cost|stringformat:"f" %}
     <span class="message-cost ms-1">{{ message.display_cost }}</span>
   {% endif %}

--- a/django/locale/translation/translations.json
+++ b/django/locale/translation/translations.json
@@ -3978,5 +3978,13 @@
     "Downloads": {
         "fr": "",
         "fr_auto": "Téléchargements"
+    },
+    "Read-only": {
+        "fr": "",
+        "fr_auto": "Lecture seule"
+    },
+    "An error occurred.": {
+        "fr": "",
+        "fr_auto": "Une erreur s’est produite."
     }
 }

--- a/django/otto/forms.py
+++ b/django/otto/forms.py
@@ -113,13 +113,15 @@ class UserGroupForm(forms.Form):
     )
     weekly_max = forms.IntegerField(
         label="Weekly budget ($ CAD)",
-        required=False,
+        required=True,
         widget=forms.NumberInput(attrs={"class": "form-control"}),
+        initial=0,
     )
     weekly_bonus = forms.IntegerField(
         label="Additional budget (this week only)",
-        required=False,
+        required=True,
         widget=forms.NumberInput(attrs={"class": "form-control"}),
+        initial=0,
     )
 
 

--- a/django/tests/chat/test_chat_procs.py
+++ b/django/tests/chat/test_chat_procs.py
@@ -160,7 +160,7 @@ async def test_htmx_stream_response_replacer(basic_user):
         chat,
         message.id,
         response_replacer=stream_generator(),
-        format=False,
+        wrap_markdown=False,
         llm=llm,
     )
     # Iterate over the response_stream generator

--- a/django/tests/chat/test_chat_readonly.py
+++ b/django/tests/chat/test_chat_readonly.py
@@ -1,0 +1,53 @@
+from django.urls import reverse
+
+import pytest
+
+from chat.models import Chat, Message
+
+
+@pytest.mark.django_db
+def test_chat(client, basic_user, all_apps_user):
+    # Create a chat with all apps user
+    # path("chat-with-ai/", views.new_chat_with_ai, name="chat_with_ai"),
+    user = all_apps_user()
+    client.force_login(user)
+    response = client.post(reverse("chat:chat_with_ai"))
+    # This should redirect to the chat page
+    assert response.status_code == 302
+    chat = Chat.objects.first()
+    assert chat.user == user
+
+    # Post a message to the chat
+    # path("id/<str:chat_id>/message/", views.chat_message, name="chat_message"),
+    response = client.post(
+        reverse("chat:chat_message", kwargs={"chat_id": chat.id}),
+        {"user-message": "Hello, world!"},
+    )
+    assert response.status_code == 200
+    # Check that the message was added to the chat
+    chat.refresh_from_db()
+    assert chat.messages.count() == 2  # 1 user message, 1 empty bot response
+    message = chat.messages.filter(is_bot=False).first()
+    assert message.text == "Hello, world!"
+
+    # Get the chat via the normal chat route
+    # path("id/<str:chat_id>/", views.chat, name="chat"),
+    response = client.get(reverse("chat:chat", kwargs={"chat_id": chat.id}))
+    assert response.status_code == 200
+    assert str(chat.id) in str(response.url)
+    assert "Hello, world!" in response.content.decode()
+    # Also check that there is a chat prompt (not readonly)
+    assert "chat-prompt" in response.content.decode()
+    assert "read only" not in response.content.decode().lower()
+
+    # Now, login as a different user
+    user = basic_user()
+    client.force_login(user)
+    # Get the chat
+    response = client.get(reverse("chat:chat", kwargs={"chat_id": chat.id}))
+    assert response.status_code == 200
+    assert str(chat.id) in str(response.url)
+    assert "Hello, world!" in response.content.decode()
+    # Check that there is no chat prompt (readonly)
+    assert "chat-prompt" not in response.content.decode()
+    assert "read only" in response.content.decode().lower()

--- a/django/tests/chat/test_chat_readonly.py
+++ b/django/tests/chat/test_chat_readonly.py
@@ -15,8 +15,7 @@ def test_chat(client, basic_user, all_apps_user):
     response = client.post(reverse("chat:chat_with_ai"))
     # This should redirect to the chat page
     assert response.status_code == 302
-    chat = Chat.objects.first()
-    assert chat.user == user
+    chat = Chat.objects.filter(user=user).last()
 
     # Post a message to the chat
     # path("id/<str:chat_id>/message/", views.chat_message, name="chat_message"),

--- a/django/tests/chat/test_chat_views.py
+++ b/django/tests/chat/test_chat_views.py
@@ -233,7 +233,7 @@ async def test_htmx_stream_stop(client, all_apps_user):
         chat,
         response_message.id,
         response_replacer=stream_generator(),
-        format=False,
+        wrap_markdown=False,
         llm=llm,
     )
     # Iterate over the response_stream generator


### PR DESCRIPTION
Users can copy the URL of their chat and share it with others. Any logged-in Otto user can view any other chat for which they have the link. Because the chats have UUIDs, this is not a security issue.

![image](https://github.com/user-attachments/assets/0476426f-d633-421b-8142-4c6e366c2546)