### PR TITLE
fix: m2m fields in default preset; move copy_options to utils.py

### DIFF
--- a/django/chat/models.py
+++ b/django/chat/models.py
@@ -11,7 +11,6 @@ from django.template.loader import render_to_string
 from django.utils import timezone
 from django.utils.translation import gettext_lazy as _
 
-from rules import is_group_member
 from structlog import get_logger
 
 from chat.prompts import (
@@ -96,9 +95,10 @@ class ChatOptionsManager(models.Manager):
         Set the mode and chat FK in the new object.
         """
         if chat and chat.user.default_preset:
-            new_options = chat.user.default_preset.options
-            if new_options:
-                new_options.pk = None
+            from chat.utils import copy_options
+
+            new_options = self.create()
+            copy_options(chat.user.default_preset.options, new_options)
         else:
             # Default Otto settings
             default_library = Library.objects.get_default_library()

--- a/django/chat/views.py
+++ b/django/chat/views.py
@@ -37,7 +37,7 @@ from chat.models import (
     Preset,
     create_chat_data_source,
 )
-from chat.utils import change_mode_to_chat_qa, title_chat
+from chat.utils import change_mode_to_chat_qa, copy_options, title_chat
 from librarian.models import Library, SavedFile
 from otto.models import SecurityLabel
 from otto.rules import can_access_preset
@@ -489,25 +489,6 @@ def chat_options(request, chat_id, action=None, preset_id=None):
     Save and load chat options.
     """
 
-    def _copy_options(source_options, target_options):
-        source_options = model_to_dict(source_options)
-        # Remove the fields that are not part of the preset
-        for field in ["id", "chat"]:
-            source_options.pop(field)
-        # Update the preset options with the dictionary
-        fk_fields = ["qa_library"]
-        m2m_fields = ["qa_data_sources", "qa_documents"]
-        # Remove None values
-        source_options = {k: v for k, v in source_options.items()}
-        for key, value in source_options.items():
-            if key in fk_fields:
-                setattr(target_options, f"{key}_id", int(value) if value else None)
-            elif key in m2m_fields:
-                getattr(target_options, key).set(value)
-            else:
-                setattr(target_options, key, value)
-        target_options.save()
-
     chat = Chat.objects.get(id=chat_id)
     # if we are loading a preset, check if the user has access to it
     if preset_id and not can_access_preset(
@@ -548,7 +529,7 @@ def chat_options(request, chat_id, action=None, preset_id=None):
             return HttpResponse(status=500)
 
         # Update the chat options with the preset options
-        _copy_options(preset.options, chat.options)
+        copy_options(preset.options, chat.options)
 
         chat_options_form = ChatOptionsForm(instance=preset.options, user=request.user)
 
@@ -582,7 +563,7 @@ def chat_options(request, chat_id, action=None, preset_id=None):
                 # save the current chat settings
                 if replace_with_settings:
                     # copy the options from the chat to the preset
-                    _copy_options(chat.options, preset.options)
+                    copy_options(chat.options, preset.options)
                     preset.options.prompt = request.POST.get("prompt", "")
                     preset.options.save()
 


### PR DESCRIPTION
Reuse the (working) `_copy_options` method from chat/views.py in chat/models.py. (Moved to a public method in chat/utils.py)