### PR TITLE
fix: librarian status updates

### DIFF
--- a/django/librarian/views.py
+++ b/django/librarian/views.py
@@ -285,6 +285,7 @@ def modal_view(request, item_type=None, item_id=None, parent_id=None):
         "poll_url": poll_url,
         "poll_response": "poll" in request.GET,
     }
+    print("poll_url (from modal_view):", poll_url)
     return render(request, "librarian/modal_inner.html", context)
 
 
@@ -305,6 +306,7 @@ def poll_status(request, data_source_id, document_id=None):
     poll_url = request.path if poll else None
 
     document = Document.objects.get(id=document_id) if document_id else None
+    print("poll_url (from poll_status):", poll_url)
     return render(
         request,
         "librarian/components/poll_update.html",

--- a/django/librarian/views.py
+++ b/django/librarian/views.py
@@ -285,7 +285,6 @@ def modal_view(request, item_type=None, item_id=None, parent_id=None):
         "poll_url": poll_url,
         "poll_response": "poll" in request.GET,
     }
-    print("poll_url (from modal_view):", poll_url)
     return render(request, "librarian/modal_inner.html", context)
 
 
@@ -300,13 +299,12 @@ def poll_status(request, data_source_id, document_id=None):
     documents = Document.objects.filter(data_source_id=data_source_id)
     poll = False
     try:
-        poll = documents.filter(status__in=[IN_PROGRESS_STATUSES]).exists()
+        poll = documents.filter(status__in=IN_PROGRESS_STATUSES).exists()
     except:
         poll = False
     poll_url = request.path if poll else None
 
     document = Document.objects.get(id=document_id) if document_id else None
-    print("poll_url (from poll_status):", poll_url)
     return render(
         request,
         "librarian/components/poll_update.html",

--- a/django/tests/librarian/test_librarian.py
+++ b/django/tests/librarian/test_librarian.py
@@ -415,7 +415,6 @@ def test_modal_views(client, all_apps_user):
     assert not LibraryUserRole.objects.filter(id=role.id).exists()
 
 
-@skip_on_github_actions
 @pytest.mark.django_db
 def test_poll_status(client, all_apps_user):
     library = Library.objects.get_default_library()

--- a/django/tests/librarian/test_librarian.py
+++ b/django/tests/librarian/test_librarian.py
@@ -413,3 +413,80 @@ def test_modal_views(client, all_apps_user):
     # Check the library object is deleted
     assert not Library.objects.filter(id=tmp_library.id).exists()
     assert not LibraryUserRole.objects.filter(id=role.id).exists()
+
+
+@skip_on_github_actions
+@pytest.mark.django_db
+def test_poll_status(client, all_apps_user):
+    library = Library.objects.get_default_library()
+    user = all_apps_user()
+    client.force_login(user)
+    data_source = DataSource.objects.create(library=library)
+    document = Document.objects.create(data_source=data_source, url="http://google.ca")
+    document2 = Document.objects.create(
+        data_source=data_source, url="http://google.com"
+    )
+    # Poll for status updates
+    url = reverse(
+        "librarian:data_source_status", kwargs={"data_source_id": data_source.id}
+    )
+    response = client.get(url)
+    # Check the context to ensure that poll_url is not None
+    assert response.context["poll_url"] is not None
+    # Check the document_status route as well
+    url = reverse(
+        "librarian:document_status",
+        kwargs={"data_source_id": data_source.id, "document_id": document.id},
+    )
+    response = client.get(url)
+    # Check the context to ensure that poll_url is not None
+    assert response.context["poll_url"] is not None
+
+    # One document completes
+    document.status = "SUCCESS"
+    document.save()
+
+    # Check both routes to ensure that poll_url still not None (since document2 isn't done)
+    url = reverse(
+        "librarian:data_source_status", kwargs={"data_source_id": data_source.id}
+    )
+    response = client.get(url)
+    assert response.context["poll_url"] is not None
+    url = reverse(
+        "librarian:document_status",
+        kwargs={"data_source_id": data_source.id, "document_id": document.id},
+    )
+    response = client.get(url)
+    assert response.context["poll_url"] is not None
+    # And the other document
+    url = reverse(
+        "librarian:document_status",
+        kwargs={"data_source_id": data_source.id, "document_id": document2.id},
+    )
+    response = client.get(url)
+    assert response.context["poll_url"] is not None
+
+    # Second document fails
+    document2.status = "ERROR"
+    document2.save()
+
+    # Check all 3 routes. All 3 should have poll_url = None
+    url = reverse(
+        "librarian:data_source_status", kwargs={"data_source_id": data_source.id}
+    )
+    response = client.get(url)
+    assert response.context["poll_url"] is None
+
+    url = reverse(
+        "librarian:document_status",
+        kwargs={"data_source_id": data_source.id, "document_id": document.id},
+    )
+    response = client.get(url)
+    assert response.context["poll_url"] is None
+
+    url = reverse(
+        "librarian:document_status",
+        kwargs={"data_source_id": data_source.id, "document_id": document2.id},
+    )
+    response = client.get(url)
+    assert response.context["poll_url"] is None


### PR DESCRIPTION
Fixes a bug where document processing status icons (in "documents" list for a particular data source in librarian modal) did not finish updating. i.e. "poll_url" was None in the context from the `poll_status` view even though there were ongoing tasks.

To test:
- start celery with a small number of concurrent tasks, i.e. 2
- upload some documents to a data source (more than 2)
- ensure that the status icons for all of them continues to update until all documents are complete, without any intervention