### PR TITLE
fix: eliminate unnecessary display functions

### DIFF
--- a/django/otto/models.py
+++ b/django/otto/models.py
@@ -338,12 +338,6 @@ class Feedback(models.Model):
 
     objects = FeedbackManager()
 
-    def status_display(self):
-        return dict(self.FEEDBACK_STATUS_CHOICES)[self.status]
-
-    def feedback_type_display(self):
-        return dict(self.FEEDBACK_TYPE_CHOICES)[self.feedback_type]
-
 
 class SecurityLabel(models.Model):
     name = models.CharField(max_length=50, unique=True)

--- a/django/otto/templates/components/feedback/dashboard/feedback_type_icon.html
+++ b/django/otto/templates/components/feedback/dashboard/feedback_type_icon.html
@@ -1,21 +1,21 @@
 {% if info.feedback.feedback_type == 'bug' %}
   <i class="bi bi-bug mx-2 fw-semibold"
      style="font-size: 1.25rem"
-     title="{{ info.feedback.feedback_type_display }}"></i>
+     title="{{ info.feedback.get_feedback_type_display }}"></i>
 {% elif info.feedback.feedback_type == 'feature_request' %}
   <i class="bi bi-lightbulb mx-2 fw-semibold"
      style="font-size: 1.25rem"
-     title="{{ info.feedback.feedback_type_display }}"></i>
+     title="{{ info.feedback.get_feedback_type_display }}"></i>
 {% elif info.feedback.feedback_type == 'feedback' %}
   <i class="bi bi-exclamation-square mx-2 fw-semibold"
      style="font-size: 1.25rem"
-     title="{{ info.feedback.feedback_type_display }}"></i>
+     title="{{ info.feedback.get_feedback_type_display }}"></i>
 {% elif info.feedback.feedback_type == 'other' %}
   <i class="bi bi-chat-left-text mx-2 fw-semibold"
      style="font-size: 1.25rem"
-     title="{{ info.feedback.feedback_type_display }}"></i>
+     title="{{ info.feedback.get_feedback_type_display }}"></i>
 {% else %}
   <i class="bi bi-question-circle mx-2 fw-semibold"
      style="font-size: 1.25rem"
-     title="{{ info.feedback.feedback_type_display }}"></i>
+     title="{{ info.feedback.get_feedback_type_display }}"></i>
 {% endif %}

--- a/django/otto/templates/components/feedback/dashboard/feedback_type_status.html
+++ b/django/otto/templates/components/feedback/dashboard/feedback_type_status.html
@@ -1,9 +1,9 @@
 {% if info.feedback.status == 'resolved' %}
-  <div class="badge badge-resolved border">{{ info.feedback.status_display }}</div>
+  <div class="badge badge-resolved border">{{ info.feedback.get_status_display }}</div>
 {% elif info.feedback.status == 'new' %}
-  <div class="badge badge-new border">{{ info.feedback.status_display }}</div>
+  <div class="badge badge-new border">{{ info.feedback.get_status_display }}</div>
 {% elif info.feedback.status == 'closed' %}
-  <div class="badge badge-closed border">{{ info.feedback.status_display }}</div>
+  <div class="badge badge-closed border">{{ info.feedback.get_status_display }}</div>
 {% else %}
-  <div class="badge badge-in-progress border">{{ info.feedback.status_display }}</div>
+  <div class="badge badge-in-progress border">{{ info.feedback.get_status_display }}</div>
 {% endif %}

--- a/django/tests/otto/test_otto_models.py
+++ b/django/tests/otto/test_otto_models.py
@@ -32,22 +32,6 @@ def test_user_pilot_name(basic_user):
 
 
 @pytest.mark.django_db
-def test_feedback_status_display(basic_user, basic_feedback):
-    user = basic_user(accept_terms=True)
-    feedback = basic_feedback(user=user)
-
-    assert feedback.status_display() == "New"
-
-
-@pytest.mark.django_db
-def test_feedback_feedback_type_display(basic_user, basic_feedback):
-    user = basic_user(accept_terms=True)
-    feedback = basic_feedback(user=user)
-
-    assert feedback.feedback_type_display() == "Feedback"
-
-
-@pytest.mark.django_db
 def test_get_feedback_stats(basic_user, basic_feedback):
     user = basic_user(accept_terms=True)
 


### PR DESCRIPTION
In the course of working on something else, I noticed that there were 500 errors popping up in the Sandbox feedback manager. It turned out to be related to a feedback item with an obsolete Type category, which was breaking the custom feedback_type_display function in the Feedback model.

Fortunately, it turns out that Django provides a built-in display method in HTML templates, which does the same thing as the custom function but also allows for obsolete categories to be displayed.
