### PR TITLE
feat: add smooth scrolling to current chat list item and enhance button visibility

### DIFF
--- a/django/chat/static/chat/js/scripts.js
+++ b/django/chat/static/chat/js/scripts.js
@@ -100,7 +100,7 @@ function scrollToListItem() {
     const currentChat = document.querySelector('.chat-list-item.current');
     if (currentChat) {
       currentChat.scrollIntoView({
-        behavior: 'smooth',
+        behavior: 'instant',
         block: 'center'
       });
     }

--- a/django/chat/static/chat/js/scripts.js
+++ b/django/chat/static/chat/js/scripts.js
@@ -95,6 +95,18 @@ function scrollToBottom(smooth = true, force = false) {
   messagesContainer.scrollTop = hashContainer ? messagesContainer.scrollTop + offset : messagesContainer.scrollHeight;
 }
 
+function scrollToListItem() {
+  setTimeout(() => {
+    const currentChat = document.querySelector('.chat-list-item.current');
+    if (currentChat) {
+      currentChat.scrollIntoView({
+        behavior: 'smooth',
+        block: 'center'
+      });
+    }
+  }, 100);
+}
+
 function handleModeChange(mode, element = null, preset_loaded = false) {
   // Set the hidden input value to the selected mode
   let hidden_mode_input = document.querySelector('#id_mode');

--- a/django/chat/static/chat/style.css
+++ b/django/chat/static/chat/style.css
@@ -277,10 +277,11 @@ pre .copy-button:focus {
   font-weight: 500;
 }
 
+.chat-list-item.current button.options,
 #left-sidebar li:hover button.options,
 #left-sidebar li:focus button.options,
 #left-sidebar button.options:focus {
-  opacity: 1;
+  opacity: 1 !important;
 }
 
 

--- a/django/chat/templates/chat/chat.html
+++ b/django/chat/templates/chat/chat.html
@@ -27,7 +27,8 @@
                 style="z-index:1"
                 type="button"
                 aria-controls="left-sidebar"
-                id="left-sidebar-toggle">
+                id="left-sidebar-toggle"
+                onClick="scrollToListItem();">
           <i class="bi bi-plus-square"></i>
           <span class="visually-hidden">{% trans "Toggle chat history sidebar" %}</span>
         </button>

--- a/django/chat/templates/chat/components/chat_history_sidebar.html
+++ b/django/chat/templates/chat/components/chat_history_sidebar.html
@@ -42,3 +42,11 @@
     </div>
   </div>
 </div>
+
+{% block page_script %}
+  <script>
+  document.addEventListener('DOMContentLoaded', () => {
+    scrollToListItem();
+  });
+  </script>
+{% endblock %}


### PR DESCRIPTION
Makes sure chat is visible in sidebar onload

Ellipsis is shown by default for current chat as well.

![image](https://github.com/user-attachments/assets/91b23174-7a47-490d-86e8-3f791fb5c68e)
