### PR TITLE
fix: qa advanced setting

### DIFF
--- a/django/chat/static/chat/js/chatOptions.js
+++ b/django/chat/static/chat/js/chatOptions.js
@@ -68,7 +68,9 @@ function clearAutocomplete(field_name) {
 
 function resetQaAutocompletes() {
   const mode = document.getElementById('id_qa_mode');
+  const e = new Event("change");
   mode.value = 'rag';
+  mode.dispatchEvent(e);
   limitScopeSelect();
   updateQaSourceForms();
   clearAutocomplete('qa_data_sources');

--- a/django/chat/static/chat/js/scripts.js
+++ b/django/chat/static/chat/js/scripts.js
@@ -102,6 +102,8 @@ function handleModeChange(mode, element = null, preset_loaded = false) {
   if (!preset_loaded) {triggerOptionSave();}
   // Set the #chat-outer class to the selected mode for mode-specific styling
   document.querySelector('#chat-outer').classList = [mode];
+  // Dispatch change event for search mode in order to trigger advance settings options
+  document.getElementById('id_qa_mode').dispatchEvent(new Event("change"));
 
   resizeOtherElements();
   // If the invoking element is an accordion-button we can stop


### PR DESCRIPTION
Fixed a bug where QA advanced settings options weren't being reset even though the QA autocomplete form was being reset. Value of qa mode was being changed but change event wasn't being dispatched which is needed to trigger the actual reset.