### PR TITLE
chore: upgrade django to 5.1.4

### DIFF
--- a/django/requirements.txt
+++ b/django/requirements.txt
@@ -4,7 +4,7 @@ retrying==1.3.4
 python-dotenv==1.0.1
 
 # Django -----------------------------------------------------------------------
-Django==5.1.1
+Django==5.1.4
 django-storages==1.14.4
 whitenoise==6.7.0
 channels==4.1.0


### PR DESCRIPTION
Dismissed dependabot PRs this month but Django has a security alert, so we should at least upgrade it to the latest patch version.