### PR TITLE
fix: prevent search from loading before login

### DIFF
--- a/django/otto/templates/base.html
+++ b/django/otto/templates/base.html
@@ -55,10 +55,9 @@
             </a>
             {{ otto_version|safe }}
           </div>
-
-          {% include 'components/search.html' %}
  
           {% if request.user.is_authenticated %}
+            {% include 'components/search.html' %}
             <button class="navbar-toggler"
                     type="button"
                     data-bs-toggle="collapse"


### PR DESCRIPTION
Sometimes the login page tries to redirect to /search/, resulting in a 500 error. It turns out that this happens if you click the login button really fast after loading the welcome page. This caused some middleware requests to happen out of order, creating the state mismatch ({"next": "/search/"} vs {"next": "/"}).

This can only happen because search.html is included in the base html template, which is extended by the welcome page. Thus, the fix is as easy as wrapping the search.html inclusion in an if-statement, so it doesn't appear without authentication (i.e. _after_ login).