### PR TITLE
perf(laws): jsonb metadata index, hnsw params

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,23 +127,7 @@ python django/manage.py load_laws_xml --reset
 * To load all laws (slow and quite expensive - around $20; 8 hours), add the `--full` flag.
 * If you leave off `--reset` it should only add laws which aren't already loaded, so you can incrementally add more.
 
-#### Speed up vector store queries
-
-To speed up queries in the vector store, you may wish to build an HNSW index on the table.
-
-(This is done automatically when the `--full` flag is used to load the laws.)
-
-```bash
-psql -U postgres -h postgres-service
-```
-
-Enter the password. Switch to the llama_index database and create the HNSW index. **This can take a while.** (an hour or more for the full set of laws).
-
-```sql
-\c llama_index
-CREATE INDEX ON data_laws_lois__ USING hnsw (embedding vector_ip_ops) WITH (m = 25, ef_construction = 300);
-```
-
+  
 ### Celery scheduler
 
 To enable the celery scheduler for local testing run the following command (from ./django):

--- a/django/chat/llm.py
+++ b/django/chat/llm.py
@@ -172,7 +172,7 @@ class OttoLLM:
         top_k: int = 5,
         vector_weight: float = 0.6,
         hnsw: bool = False,
-        use_jsonb: bool = True,
+        use_jsonb: bool = False,
     ) -> QueryFusionRetriever:
 
         pg_idx = self.get_index(vector_store_table, hnsw=hnsw, use_jsonb=use_jsonb)
@@ -203,7 +203,7 @@ class OttoLLM:
         return hybrid_retriever
 
     def get_index(
-        self, vector_store_table: str, hnsw: bool = False, use_jsonb: bool = True
+        self, vector_store_table: str, hnsw: bool = False, use_jsonb: bool = False
     ) -> VectorStoreIndex:
         vector_store = OttoVectorStore.from_params(
             database=settings.DATABASES["vector_db"]["NAME"],

--- a/django/chat/llm.py
+++ b/django/chat/llm.py
@@ -218,7 +218,7 @@ class OttoLLM:
             perform_setup=True,
             use_jsonb=use_jsonb,
             hnsw_kwargs=(
-                {"hnsw_ef_construction": 500, "hnsw_m": 48, "hnsw_ef_search": 500}
+                {"hnsw_ef_construction": 256, "hnsw_m": 32, "hnsw_ef_search": 256}
                 if hnsw
                 else None
             ),

--- a/django/chat/llm.py
+++ b/django/chat/llm.py
@@ -171,9 +171,11 @@ class OttoLLM:
         filters: MetadataFilters = None,
         top_k: int = 5,
         vector_weight: float = 0.6,
+        hnsw: bool = False,
+        use_jsonb: bool = True,
     ) -> QueryFusionRetriever:
 
-        pg_idx = self.get_index(vector_store_table)
+        pg_idx = self.get_index(vector_store_table, hnsw=hnsw, use_jsonb=use_jsonb)
 
         vector_retriever = pg_idx.as_retriever(
             vector_store_query_mode="default",
@@ -201,7 +203,7 @@ class OttoLLM:
         return hybrid_retriever
 
     def get_index(
-        self, vector_store_table: str, hnsw: bool = False
+        self, vector_store_table: str, hnsw: bool = False, use_jsonb: bool = True
     ) -> VectorStoreIndex:
         vector_store = OttoVectorStore.from_params(
             database=settings.DATABASES["vector_db"]["NAME"],
@@ -214,6 +216,7 @@ class OttoLLM:
             hybrid_search=True,
             text_search_config="english",
             perform_setup=True,
+            use_jsonb=use_jsonb,
             hnsw_kwargs=(
                 {"hnsw_ef_construction": 500, "hnsw_m": 48, "hnsw_ef_search": 500}
                 if hnsw

--- a/django/laws/management/commands/load_laws_xml.py
+++ b/django/laws/management/commands/load_laws_xml.py
@@ -848,7 +848,7 @@ class Command(BaseCommand):
         # Run SQL to (re)create the JSONB metadata index and HNSW index
         post_load_sql = (
             "DROP INDEX IF EXISTS laws_lois_metadata__idx;"
-            "CREATE INDEX laws_lois_metadata__idx ON data_laws_lois__ USING GIN (metadata_ jsonb_path_ops);"
+            "CREATE INDEX laws_metadata_index ON data_laws_lois__ USING GIN (metadata_);"
             "DROP INDEX IF EXISTS data_laws_lois___embedding_idx;"
             "CREATE INDEX ON data_laws_lois__ USING hnsw (embedding vector_cosine_ops) WITH (m='32', ef_construction='256');"
         )

--- a/django/laws/management/commands/load_laws_xml.py
+++ b/django/laws/management/commands/load_laws_xml.py
@@ -758,22 +758,22 @@ class Command(BaseCommand):
                 "C-15.31",  # Canadian Environmental Protection Act, 1999
                 "C-24.5",  # Cannabis Act
                 "SOR-2018-144",  # Cannabis Regulations
-                "C-46",  # Criminal Code
-                "SOR-2021-25",  # Cross-border Movement of Hazardous Waste and Hazardous Recyclable Material Regulations
-                "F-14",  # Fisheries Act
-                "SOR-93-53",  # Fishery (General) Regulations
-                "C.R.C.,_c._870",  # Food and Drug Regulations
-                "F-27",  # Food and Drugs Act
-                "I-2.5",  # Immigration and Refugee Protection Act
-                "SOR-2002-227",  # Immigration and Refugee Protection Regulations
-                "I-21",  # Interpretation Act
-                "SOR-2016-151",  # Multi-Sector Air Pollutants Regulations
-                "SOR-2010-189",  # Renewable Fuels Regulations
-                "S-22",  # Statutory Instruments Act
-                "C.R.C.,_c._1509",  # Statutory Instruments Regulations
-                "A-1",  # Access to Information Act
-                "F-11",  # Financial Administration Act
-                "N-22",  # Canadian Navigable Waters Act
+                # "C-46",  # Criminal Code
+                # "SOR-2021-25",  # Cross-border Movement of Hazardous Waste and Hazardous Recyclable Material Regulations
+                # "F-14",  # Fisheries Act
+                # "SOR-93-53",  # Fishery (General) Regulations
+                # "C.R.C.,_c._870",  # Food and Drug Regulations
+                # "F-27",  # Food and Drugs Act
+                # "I-2.5",  # Immigration and Refugee Protection Act
+                # "SOR-2002-227",  # Immigration and Refugee Protection Regulations
+                # "I-21",  # Interpretation Act
+                # "SOR-2016-151",  # Multi-Sector Air Pollutants Regulations
+                # "SOR-2010-189",  # Renewable Fuels Regulations
+                # "S-22",  # Statutory Instruments Act
+                # "C.R.C.,_c._1509",  # Statutory Instruments Regulations
+                # "A-1",  # Access to Information Act
+                # "F-11",  # Financial Administration Act
+                # "N-22",  # Canadian Navigable Waters Act
             ]
 
         file_path_tuples = _get_en_fr_law_file_paths(laws_root, law_ids)
@@ -808,7 +808,9 @@ class Command(BaseCommand):
         if reset:
             Law.reset()
             # Recreate the table
-            OttoLLM().get_retriever("laws_lois__").retrieve("?")
+            OttoLLM().get_retriever("laws_lois__", hnsw=True, use_jsonb=True).retrieve(
+                "?"
+            )
 
         xslt_path = os.path.join(laws_root, "xslt", "LIMS2HTML.xsl")
 

--- a/django/laws/models.py
+++ b/django/laws/models.py
@@ -88,7 +88,7 @@ class LawManager(models.Manager):
         if add_to_vector_store:
             if llm is None:
                 return
-            idx = llm.get_index("laws_lois__", hnsw=True)
+            idx = llm.get_index("laws_lois__", hnsw=True, use_jsonb=True)
             nodes = []
             if existing_law.exists():
                 # Remove the old content from the vector store
@@ -165,5 +165,5 @@ class Law(models.Model):
 
     @classmethod
     def get_index(cls):
-        idx = OttoLLM().get_index("laws_lois__")
+        idx = OttoLLM().get_index("laws_lois__", hnsw=True, use_jsonb=True)
         return idx

--- a/django/laws/models.py
+++ b/django/laws/models.py
@@ -88,7 +88,7 @@ class LawManager(models.Manager):
         if add_to_vector_store:
             if llm is None:
                 return
-            idx = llm.get_index("laws_lois__", hnsw=True, use_jsonb=True)
+            idx = llm.get_index("laws_lois__", use_jsonb=True)
             nodes = []
             if existing_law.exists():
                 # Remove the old content from the vector store
@@ -102,7 +102,7 @@ class LawManager(models.Manager):
             if fr_hash_changed or force_update:
                 nodes.append(document_fr)
                 nodes.extend(nodes_fr)
-            batch_size = 128
+            batch_size = 16
             logger.debug(
                 f"Embedding & inserting nodes into vector store (batch size={batch_size} nodes)..."
             )
@@ -165,5 +165,5 @@ class Law(models.Model):
 
     @classmethod
     def get_index(cls):
-        idx = OttoLLM().get_index("laws_lois__", hnsw=True, use_jsonb=True)
+        idx = OttoLLM().get_index("laws_lois__", use_jsonb=True)
         return idx

--- a/django/laws/views.py
+++ b/django/laws/views.py
@@ -237,10 +237,10 @@ def search(request):
         ]
 
         query = request.POST.get("query")
-        # Trim query to 10000 characters
-        query_too_long = len(query) > 10000
+        # Trim query to 5000 characters
+        query_too_long = len(query) > 5000
         if query_too_long:
-            query = query[:10000] + "..."
+            query = query[:5000] + "..."
         pg_idx = llm.get_index("laws_lois__", hnsw=True, use_jsonb=True)
 
         advanced_mode = request.POST.get("advanced") == "true"
@@ -249,7 +249,7 @@ def search(request):
         selected_laws = Law.objects.all()
 
         logger.info(
-            "Search query",
+            "Law search query",
             query=query,
             advanced_mode=advanced_mode,
             disable_llm=disable_llm,
@@ -362,7 +362,7 @@ def search(request):
                 vector_store_query_mode="default",
                 similarity_top_k=top_k,
                 filters=filters,
-                vector_store_kwargs={"hnsw_ef_search": 500},
+                vector_store_kwargs={"hnsw_ef_search": 256},
             )
         elif vector_ratio == 0:
             retriever = pg_idx.as_retriever(
@@ -370,18 +370,26 @@ def search(request):
                 similarity_top_k=top_k,
                 filters=filters,
             )
+            retriever._vector_store.is_embedding_query = False
         else:
             vector_retriever = pg_idx.as_retriever(
                 vector_store_query_mode="default",
                 similarity_top_k=max(top_k * 2, 100),
                 filters=filters,
-                vector_store_kwargs={"hnsw_ef_search": 500},
+                vector_store_kwargs={"hnsw_ef_search": 256},
             )
-            text_retriever = pg_idx.as_retriever(
+            # Need to create a separate OttoLLM instance so that we can
+            # set is_embedding_query to False for the text retriever.
+            # This is a hack for LlamaIndex PGVectorStore implementation
+            # because otherwise it would embed the query even though
+            # we are just doing a postgres text search.
+            pg_idx2 = OttoLLM().get_index("laws_lois__", hnsw=True, use_jsonb=True)
+            text_retriever = pg_idx2.as_retriever(
                 vector_store_query_mode="sparse",
                 similarity_top_k=max(top_k * 2, 100),
                 filters=filters,
             )
+            text_retriever._vector_store.is_embedding_query = False
             retriever = QueryFusionRetriever(
                 retrievers=[vector_retriever, text_retriever],
                 mode="relative_score",

--- a/django/laws/views.py
+++ b/django/laws/views.py
@@ -241,7 +241,7 @@ def search(request):
         query_too_long = len(query) > 10000
         if query_too_long:
             query = query[:10000] + "..."
-        pg_idx = llm.get_index("laws_lois__", hnsw=True)
+        pg_idx = llm.get_index("laws_lois__", hnsw=True, use_jsonb=True)
 
         advanced_mode = request.POST.get("advanced") == "true"
         disable_llm = not (request.POST.get("ai_answer", False) == "on")

--- a/django/otto/management/commands/test_laws_query.py
+++ b/django/otto/management/commands/test_laws_query.py
@@ -70,7 +70,7 @@ def fake_laws_search(query):
     filters = MetadataFilters(filters=filters)
     # filters = None
     mock = True
-    vector_ratio = 1
+    vector_ratio = 0.5
 
     if vector_ratio == 1:
         pg_idx = OttoLLM(mock_embedding=mock).get_index("laws_lois__", use_jsonb=True)
@@ -78,7 +78,7 @@ def fake_laws_search(query):
             vector_store_query_mode="default",
             similarity_top_k=top_k,
             filters=filters,
-            vector_store_kwargs={"hnsw_ef_search": 128},
+            vector_store_kwargs={"hnsw_ef_search": 256},
         )
     elif vector_ratio == 0:
         pg_idx = OttoLLM(mock_embedding=mock).get_index("laws_lois__", use_jsonb=True)
@@ -95,7 +95,7 @@ def fake_laws_search(query):
             vector_store_query_mode="default",
             similarity_top_k=max(top_k * 2, 100),
             filters=filters,
-            vector_store_kwargs={"hnsw_ef_search": 128},
+            vector_store_kwargs={"hnsw_ef_search": 256},
         )
         pg_idx2 = OttoLLM(mock_embedding=mock).get_index("laws_lois__", use_jsonb=True)
         text_retriever = pg_idx2.as_retriever(

--- a/django/otto/management/commands/test_laws_query.py
+++ b/django/otto/management/commands/test_laws_query.py
@@ -1,0 +1,115 @@
+from django.core.exceptions import ObjectDoesNotExist
+from django.core.management import call_command
+from django.core.management.base import BaseCommand
+
+from langdetect import detect
+from llama_index.core.retrievers import QueryFusionRetriever
+from llama_index.core.vector_stores.types import MetadataFilter, MetadataFilters
+
+from chat.llm import OttoLLM
+from chat.models import Preset
+from laws.models import Law
+from otto.models import Group, User
+
+
+def fake_laws_search(query):
+
+    llm = OttoLLM(mock_embedding=True)
+
+    # time.sleep(60)
+    # We don't want to search Document nodes - only chunks
+    filters = [
+        MetadataFilter(
+            key="node_type",
+            value="chunk",
+            operator="==",
+        ),
+    ]
+
+    # Trim query to 10000 characters
+    query_too_long = len(query) > 10000
+    if query_too_long:
+        query = query[:10000] + "..."
+    pg_idx = llm.get_index("laws_lois__", hnsw=True)
+
+    selected_laws = Law.objects.all()
+
+    vector_ratio = 0
+    top_k = 25
+    # Options for the AI answer
+    trim_redundant = True
+    context_tokens = 2000
+    additional_instructions = (
+        "If the context information is entirely unrelated to the provided query,"
+        "don't try to answer the question; just say "
+        "'Sorry, I cannot answer that question.'."
+    )
+    doc_id_list = [law.node_id_en for law in selected_laws] + [
+        law.node_id_fr for law in selected_laws
+    ]
+
+    filters.append(
+        MetadataFilter(
+            key="doc_id",
+            value=doc_id_list,
+            operator="in",
+        )
+    )
+
+    filters = MetadataFilters(filters=filters)
+    filters = None
+
+    if vector_ratio == 1:
+        retriever = pg_idx.as_retriever(
+            vector_store_query_mode="default",
+            similarity_top_k=top_k,
+            filters=filters,
+            vector_store_kwargs={"hnsw_ef_search": 500},
+        )
+    elif vector_ratio == 0:
+        retriever = pg_idx.as_retriever(
+            vector_store_query_mode="sparse",
+            similarity_top_k=top_k,
+            filters=filters,
+        )
+        retriever._vector_store.is_embedding_query = False
+    else:
+        vector_retriever = pg_idx.as_retriever(
+            vector_store_query_mode="default",
+            similarity_top_k=max(top_k * 2, 100),
+            filters=filters,
+            vector_store_kwargs={"hnsw_ef_search": 500},
+        )
+        text_retriever = pg_idx.as_retriever(
+            vector_store_query_mode="sparse",
+            similarity_top_k=max(top_k * 2, 100),
+            filters=filters,
+        )
+        text_retriever._vector_store.is_embedding_query = False
+        retriever = QueryFusionRetriever(
+            retrievers=[vector_retriever, text_retriever],
+            mode="relative_score",
+            llm=llm.llm,
+            similarity_top_k=top_k,
+            num_queries=1,
+            use_async=False,
+            retriever_weights=[vector_ratio, 1 - vector_ratio],
+        )
+
+    try:
+        sources = retriever.retrieve(query)
+    except:
+        sources = None
+    return sources
+
+
+class Command(BaseCommand):
+    help = "Tests Preset.objects.get_accessible_presets()"
+
+    def handle(self, *args, **options):
+        from time import time
+
+        start = time()
+        for _ in range(100):
+            sources = fake_laws_search("what is the most important law in the world?")
+        print(time() - start)

--- a/django/otto/management/commands/test_laws_query.py
+++ b/django/otto/management/commands/test_laws_query.py
@@ -30,7 +30,7 @@ def fake_laws_search(query):
 
     selected_laws = Law.objects.all()
 
-    vector_ratio = 1
+    vector_ratio = 0.5
     top_k = 25
     doc_id_list = [law.node_id_en for law in selected_laws] + [
         law.node_id_fr for law in selected_laws
@@ -76,7 +76,7 @@ def fake_laws_search(query):
             vector_store_query_mode="default",
             similarity_top_k=top_k,
             filters=filters,
-            vector_store_kwargs={"hnsw_ef_search": 250},
+            vector_store_kwargs={"hnsw_ef_search": 256},
         )
     elif vector_ratio == 0:
         pg_idx = OttoLLM(mock_embedding=True).get_index("laws_lois__", use_jsonb=True)
@@ -93,7 +93,7 @@ def fake_laws_search(query):
             vector_store_query_mode="default",
             similarity_top_k=max(top_k * 2, 100),
             filters=filters,
-            vector_store_kwargs={"hnsw_ef_search": 250},
+            vector_store_kwargs={"hnsw_ef_search": 256},
         )
         pg_idx2 = OttoLLM(mock_embedding=True).get_index("laws_lois__", use_jsonb=True)
         text_retriever = pg_idx2.as_retriever(

--- a/django/otto/management/commands/test_laws_results.txt
+++ b/django/otto/management/commands/test_laws_results.txt
@@ -10,6 +10,23 @@ Results for 10x loop of same query:
 
 ----
 
-small set of laws with mock embeddings (loop of 100 queries)
+"small-medium" set of laws (medium but only up to and including cannabis)
 
-No filters, no hnsw, no embed: 6.75s
+100x:
+all filters, no jsonb index: 26s
+with jsonb index: 23s
+no filters: 20s
+
+no filters, vector search, ef_search=500: 30s
+no filters, ef_search=50: 15s
+ef_search=100: 15.5s
+ef_search=200: 17.5s
+ef_search=300: 19s
+No HNSW params: 14.8s (???)
+ - This is because default HNSW ef_search is 40 in pgvector.
+ - Even if you specify hnsw=False when constructing PGVectorStore,
+   if the index already exists it will use it with param ef_search=40
+after drop hnsw index: 75s
+
+filters on, text only: 24s
+filters on, vector only: 

--- a/django/otto/management/commands/test_laws_results.txt
+++ b/django/otto/management/commands/test_laws_results.txt
@@ -28,11 +28,11 @@ No HNSW params: 14.8s (???)
 after drop hnsw index: 75s
 
 // Latest results after HNSW tweaks
-// (build index after real embedding; m=32, ef_construction=64)
-100x queries, filters enabled, JSONB with metadata index, HNSW ef_search=150
-Text only: 11s
-Vector only: 55s
-Hybrid: 66s
+// (build index after real embedding; m=32, ef_construction=256)
+10x queries, hnsw ef_search 256.
 
-With ef_search=250
-Hybrid: 67s (great, lets do this)
+(This includes all the "medium" set of laws)
+text only, no filters: 1.1s
+text only, with filters: 1.8s
+vector only (mock embedding), with filters: 5.0s
+hybrid with filters: 6.6s

--- a/django/otto/management/commands/test_laws_results.txt
+++ b/django/otto/management/commands/test_laws_results.txt
@@ -1,0 +1,15 @@
+Results for 10x loop of same query:
+
+36s - with filters
+10s - no filters
+( all no filters below )
+4.5s - vector only
+4.5s - text only (still calls embedding API!)
+1.9s - text only, - after setting "retriever._vector_store.is_embedding_query = False"
+
+
+----
+
+small set of laws with mock embeddings (loop of 100 queries)
+
+No filters, no hnsw, no embed: 6.75s

--- a/django/otto/management/commands/test_laws_results.txt
+++ b/django/otto/management/commands/test_laws_results.txt
@@ -7,7 +7,6 @@ Results for 10x loop of same query:
 4.5s - text only (still calls embedding API!)
 1.9s - text only, - after setting "retriever._vector_store.is_embedding_query = False"
 
-
 ----
 
 "small-medium" set of laws (medium but only up to and including cannabis)
@@ -28,5 +27,12 @@ No HNSW params: 14.8s (???)
    if the index already exists it will use it with param ef_search=40
 after drop hnsw index: 75s
 
-filters on, text only: 24s
-filters on, vector only: 
+// Latest results after HNSW tweaks
+// (build index after real embedding; m=32, ef_construction=64)
+100x queries, filters enabled, JSONB with metadata index, HNSW ef_search=150
+Text only: 11s
+Vector only: 55s
+Hybrid: 66s
+
+With ef_search=250
+Hybrid: 67s (great, lets do this)


### PR DESCRIPTION
- Use JSONB for storing metadata for laws and add GIN index on metadata
  - reduced from **2.6s to 0.07s per iteration**
- Build HNSW index *after* loading all laws.
  - increases accuracy and performance (see https://www.pinecone.io/blog/hnsw-not-enough/)
  - improves speed of loading laws
- Adjust HNSW parameters
  - TODO: grid search / benchmark different parameters for laws search specifically.
  - Based on benchmarks here: https://www.pinecone.io/learn/series/faiss/hnsw/

Need to manually run `load_laws_xml --reset` when upgrading. For local testing you could do this with the "--small" flag.