### PR TITLE
fix: law sources view needs json.loads (after switch to JSONB)

### DIFF
--- a/django/laws/management/commands/load_laws_xml.py
+++ b/django/laws/management/commands/load_laws_xml.py
@@ -860,6 +860,8 @@ class Command(BaseCommand):
 
         # Run SQL to (re)create the JSONB metadata index and HNSW index
         post_load_sql = (
+            "DROP INDEX IF EXISTS laws_lois_node_id__idx;"
+            "CREATE INDEX laws_lois_node_id__idx ON data_laws_lois__ (node_id);"
             "DROP INDEX IF EXISTS laws_lois_metadata__idx;"
             "CREATE INDEX laws_metadata_index ON data_laws_lois__ USING GIN (metadata_);"
             "DROP INDEX IF EXISTS data_laws_lois___embedding_idx;"

--- a/django/laws/static/laws/law_search.js
+++ b/django/laws/static/laws/law_search.js
@@ -96,6 +96,7 @@ function showSourceDetails(button) {
   card.classList.add("border-4");
   details.classList.remove('d-none');
 }
+
 function findSimilar(el) {
   const text = el.getAttribute('data-text');
   // Populate the search form with the text

--- a/django/laws/static/laws/style.css
+++ b/django/laws/static/laws/style.css
@@ -116,7 +116,8 @@ button#basic-search-button {
   padding-right: 5.4rem !important;
   field-sizing: content;
   margin-bottom: 24px;
-  resize: none;
+  resize: vertical;
+  max-height: 200px;
 }
 
 #basic-search-input::placeholder {

--- a/django/laws/utils.py
+++ b/django/laws/utils.py
@@ -1,4 +1,5 @@
 import asyncio
+import json
 
 from django.core.cache import cache
 from django.db import connections
@@ -31,7 +32,7 @@ def get_source_node(node_id):
         if row:
             return {
                 "text": row[0],
-                "metadata": row[1],
+                "metadata": json.loads(row[1]),
             }
     return None
 


### PR DESCRIPTION
Added Pytest also.

To test manually, search for something in the laws view then click the 3 dots on one of the returned sources. (in main branch, this causes an error)