### PR TITLE
fix: update GoC root certificate download method in Dockerfile

### DIFF
--- a/django/Dockerfile
+++ b/django/Dockerfile
@@ -16,10 +16,10 @@ RUN apt-get update \
     && rm -rf /var/cache/apt/archives/*
 
 # Download and install the GoC root certificate using wget
-# TODO: Remove this hard-coded entry when the host no longer resets the connection the other IP
-RUN echo "167.43.15.18 pki-icp.canada.ca" >> /etc/hosts \
-    && wget -q http://pki-icp.canada.ca/aia/GoC-GdC-Root-A.crt -O /usr/local/share/ca-certificates/GoC-GdC-Root-A.crt \
+# TODO: Replace the IP with pki-icp.canada.ca when the host no longer resets the connection from the secondary IP
+RUN wget -q http://167.43.15.18/aia/GoC-GdC-Root-A.crt -O /usr/local/share/ca-certificates/GoC-GdC-Root-A.crt \
     && update-ca-certificates
+
 
 COPY requirements*.txt /tmp/pip-tmp/
 RUN pip3 --disable-pip-version-check --no-cache-dir install \


### PR DESCRIPTION
The hosts file started giving a write-protection error. The IP seemed to work and should still work with the Fortigate rule since the rules are IP-based. The Azure Firewall needed to be changed to reflect this, but that's in the otto-infra repo.