### PR TITLE
fix: goc cert IP

### DIFF
--- a/django/Dockerfile
+++ b/django/Dockerfile
@@ -15,11 +15,13 @@ RUN apt-get update \
     && rm -rf /var/lib/apt/lists/* \
     && rm -rf /var/cache/apt/archives/*
 
-# Download and install the GoC root certificate using wget
-# TODO: Replace the IP with pki-icp.canada.ca when the host no longer resets the connection from the secondary IP
-RUN wget -q http://167.43.15.18/aia/GoC-GdC-Root-A.crt -O /usr/local/share/ca-certificates/GoC-GdC-Root-A.crt \
-    && update-ca-certificates
+# Update /etc/hosts to map the domain to the specific IP address
+# TODO: Remove this step when the host no longer resets the connection from the secondary IP
+RUN echo "167.43.15.18 pki-icp.canada.ca" >> /etc/hosts
 
+# Download and install the GoC root certificate using wget
+RUN wget -q http://pki-icp.canada.ca/aia/GoC-GdC-Root-A.crt -O /usr/local/share/ca-certificates/GoC-GdC-Root-A.crt \
+    && update-ca-certificates
 
 COPY requirements*.txt /tmp/pip-tmp/
 RUN pip3 --disable-pip-version-check --no-cache-dir install \

--- a/django/Dockerfile
+++ b/django/Dockerfile
@@ -15,12 +15,9 @@ RUN apt-get update \
     && rm -rf /var/lib/apt/lists/* \
     && rm -rf /var/cache/apt/archives/*
 
-# Update /etc/hosts to map the domain to the specific IP address
-# TODO: Remove this step when the host no longer resets the connection from the secondary IP
-RUN echo "167.43.15.18 pki-icp.canada.ca" >> /etc/hosts
-
 # Download and install the GoC root certificate using wget
-RUN wget -q http://pki-icp.canada.ca/aia/GoC-GdC-Root-A.crt -O /usr/local/share/ca-certificates/GoC-GdC-Root-A.crt \
+# TODO: Remove the header and replace the IP with the domain name when the host no longer resets the connection from the secondary IP
+RUN RUN wget -q --header="Host: pki-icp.canada.ca" http://167.43.15.18/aia/GoC-GdC-Root-A.crt -O /usr/local/share/ca-certificates/GoC-GdC-Root-A.crt \
     && update-ca-certificates
 
 COPY requirements*.txt /tmp/pip-tmp/

--- a/django/Dockerfile
+++ b/django/Dockerfile
@@ -17,7 +17,7 @@ RUN apt-get update \
 
 # Download and install the GoC root certificate using wget
 # TODO: Remove the header and replace the IP with the domain name when the host no longer resets the connection from the secondary IP
-RUN RUN wget -q --header="Host: pki-icp.canada.ca" http://167.43.15.18/aia/GoC-GdC-Root-A.crt -O /usr/local/share/ca-certificates/GoC-GdC-Root-A.crt \
+RUN wget -q --header="Host: pki-icp.canada.ca" http://167.43.15.18/aia/GoC-GdC-Root-A.crt -O /usr/local/share/ca-certificates/GoC-GdC-Root-A.crt \
     && update-ca-certificates
 
 COPY requirements*.txt /tmp/pip-tmp/


### PR DESCRIPTION
Writing the hosts file didn't work. Using just the IP without providing header didn't work. This PR fixes that by including the header in the wget request.