### PR TITLE
fix drag leave events

### DIFF
--- a/django/chat/templates/chat/components/file_upload.html
+++ b/django/chat/templates/chat/components/file_upload.html
@@ -67,7 +67,8 @@
   let dropZone = document.querySelector('#file-dropzone');
   window.addEventListener('dragenter', handleDragEnter);
   dropZone.addEventListener('dragover', ePrevent);
-  dropZone.addEventListener('dragleave', handleDragLeave);
+  window.addEventListener('dragleave', handleDragLeave);
+  window.addEventListener('dragexit', handleDragLeave);
   dropZone.addEventListener('drop', onDrop);
 
   // Monitor the form #chat-file-form for changes


### PR DESCRIPTION
Fixes issue where dragging files into the AI assistant - but not completing the drag-drop action - would keep the dropzone lightbox on the screen indefinitely.
Now the dropzone disappears when dragging cursor leaves the window.