### PR TITLE
fix: add hx-redirect to login when required

### DIFF
--- a/django/otto/utils/auth.py
+++ b/django/otto/utils/auth.py
@@ -1,11 +1,7 @@
-from django.conf import settings
-from django.core.cache import cache
-from django.http import HttpResponseRedirect
-from django.urls import path, reverse
+from django.http import HttpResponse, HttpResponseRedirect
+from django.urls import reverse
 
 from structlog import get_logger
-
-from otto.views import load_test
 
 logger = get_logger(__name__)
 
@@ -62,8 +58,11 @@ class RedirectToLoginMiddleware:
             return self.get_response(request)
         # AC-2, AC-19: User Authentication (Can't be anonymous)
         if not request.user.is_authenticated or request.user.is_anonymous:
+            if request.headers.get("HX-Request"):
+                response = HttpResponse(status=200)
+                response["HX-Redirect"] = reverse("welcome")
+                return response
             return HttpResponseRedirect(reverse("welcome") + "?next=" + request.path)
-
         return self.get_response(request)
 
 

--- a/django/otto/views.py
+++ b/django/otto/views.py
@@ -536,7 +536,7 @@ def manage_pilots_form(request, pilot_id=None):
         pilot.delete()
         response = HttpResponse()
         # Add hx-redirect header to trigger HTMX redirect
-        response["hx-redirect"] = reverse("manage_pilots")
+        response["HX-Redirect"] = reverse("manage_pilots")
         return response
     if pilot_id:
         pilot = get_object_or_404(Pilot, pk=pilot_id)


### PR DESCRIPTION
To replicate existing issue:
* on `main` branch, open Otto. Log in. Open a second tab. Log out in that tab. Return to the first Otto tab. After 1 minute, the HTMX request to user_cost will result in the login page being superimposed over the homepage.

To test this branch:
* repeat the same steps. The first tab should redirect to the login page rather than superimposing it.