### PR TITLE
refactor: remove backend code for reset button

### DIFF
--- a/django/chat/views.py
+++ b/django/chat/views.py
@@ -496,30 +496,8 @@ def chat_options(request, chat_id, action=None, preset_id=None):
         "chat.access_preset", Preset.objects.get(id=preset_id)
     ):
         return HttpResponse(status=403)
-    if action == "reset":
-        # Check if chat.options already exists
-        if hasattr(chat, "options") and chat.options:
-            # Delete the existing ChatOptions object
-            chat.options.delete()
 
-        chat.options = ChatOptions.objects.from_defaults(chat=chat)
-        chat.loaded_preset = None
-        chat.save()
-        logger.info("Resetting chat options to default.", chat_id=chat_id)
-
-        return render(
-            request,
-            "chat/components/chat_options_accordion.html",
-            {
-                "options_form": ChatOptionsForm(
-                    instance=chat.options, user=request.user
-                ),
-                "preset_loaded": "true",
-                "prompt": chat.options.prompt,
-            },
-        )
-
-    elif action == "load_preset":
+    if action == "load_preset":
         logger.info(
             "Loading chat options from a preset.",
             chat_id=chat_id,

--- a/django/tests/chat/test_chat_options.py
+++ b/django/tests/chat/test_chat_options.py
@@ -111,13 +111,6 @@ def test_chat_options(client, all_apps_user):
         == "start each response with 'Yeehaw!'"
     )
 
-    # Reset the chat options
-    response = client.post(
-        reverse("chat:chat_options", args=[new_chat.id, "reset"]),
-        preset_form_data,
-    )
-    assert response.status_code == 200
-
     # Finally, delete the Cowboy AI preset
     response = client.post(
         reverse("chat:chat_options", args=[new_chat.id, "delete_preset", preset.id]),

--- a/django/tests/chat/test_chat_views.py
+++ b/django/tests/chat/test_chat_views.py
@@ -1102,23 +1102,6 @@ def test_preset(client, basic_user, all_apps_user):
     chat2.options.qa_pre_instructions = ""
     chat2.options.save()
 
-    # Reset to default preset (action="reset")
-    response = client.post(
-        reverse(
-            "chat:chat_options",
-            kwargs={
-                "chat_id": chat2.id,
-                "action": "reset",
-            },
-        )
-    )
-    assert response.status_code == 200
-    chat2.refresh_from_db()
-    # Chat2 should now have the preset loaded
-    assert chat2.options.qa_pre_instructions == "The quick brown fox"
-    # But the library should be reset to user2's personal library
-    assert chat2.options.qa_library == user2.personal_library
-
 
 def test_update_qa_options_from_librarian(client, all_apps_user):
     from librarian.models import DataSource, Document, Library


### PR DESCRIPTION
A follow up on the previous refactor: Move preset browser up PR https://github.com/justicecanada/otto/commit/a746613885f57d99b77c6c3182589f8474f938cf