### PR TITLE
fix: context length issue for tree_summarizer

### DIFF
--- a/django/chat/llm.py
+++ b/django/chat/llm.py
@@ -265,8 +265,8 @@ class OttoLLM:
     # Private helpers
     def _get_tree_summarizer(
         self,
-        summary_template: PromptTemplate = None,
         prompt_helper: PromptHelper = None,
+        summary_template: PromptTemplate = None,
     ) -> TreeSummarize:
         return TreeSummarize(
             llm=self.llm,

--- a/django/chat/llm.py
+++ b/django/chat/llm.py
@@ -134,7 +134,7 @@ class OttoLLM:
                 num_output=self.max_output_tokens,
             )
             response = await self._get_tree_summarizer(
-                summary_template=template, prompt_helper=custom_prompt_helper
+                prompt_helper=custom_prompt_helper, summary_template=template
             ).aget_response(query, [context])
             response_text = ""
             async for chunk in response:

--- a/django/chat/llm.py
+++ b/django/chat/llm.py
@@ -123,6 +123,8 @@ class OttoLLM:
         context: str,
         query: str = "summarize the text",
         template: PromptTemplate = None,
+        chunk_size_limit: int = 64000,
+        chunk_overlap_ratio: float = 0.1,
     ):
         """
         Stream complete response (not single tokens) from context string and query.
@@ -132,6 +134,8 @@ class OttoLLM:
             custom_prompt_helper = PromptHelper(
                 context_window=self.max_input_tokens,
                 num_output=self.max_output_tokens,
+                chunk_size_limit=chunk_size_limit,
+                chunk_overlap_ratio=chunk_overlap_ratio,
             )
             response = await self._get_tree_summarizer(
                 prompt_helper=custom_prompt_helper, summary_template=template

--- a/django/chat/llm.py
+++ b/django/chat/llm.py
@@ -60,6 +60,10 @@ class OttoLLM:
         "gpt-4o-mini": 128000,
         "gpt-4o": 128000,
     }
+    _deployment_to_max_output_tokens_mapping = {
+        "gpt-4o-mini": 16384,
+        "gpt-4o": 16384,
+    }
 
     def __init__(
         self,
@@ -80,6 +84,9 @@ class OttoLLM:
         self.mock_embedding = mock_embedding
         self.embed_model = self._get_embed_model()
         self.max_input_tokens = self._deployment_to_max_input_tokens_mapping[deployment]
+        self.max_output_tokens = self._deployment_to_max_output_tokens_mapping[
+            deployment
+        ]
 
     # Convenience methods to interact with LLM
     # Each will return a complete response (not single tokens)
@@ -123,8 +130,8 @@ class OttoLLM:
         """
         try:
             custom_prompt_helper = PromptHelper(
-                context_window=128000,
-                num_output=4096,
+                context_window=self.max_input_tokens,
+                num_output=self.max_output_tokens,
             )
             response = await self._get_tree_summarizer(
                 summary_template=template, prompt_helper=custom_prompt_helper


### PR DESCRIPTION
llama index uses this equation to calculate the context size of each text chunk for tree summarization:
 
context_size_tokens = self.context_window - num_prompt_tokens - self.num_output

where self.num_output is the number of tokens to leave space for the generated output. By default this value was being set to 256 which is not enough in our case especially when we want to generate a long summary. This was causing a context overflow for big documents that heavily exceeded the 128K token input limit because llama index was creating chunks of around 127.7K, which left no room for the model to generate a response, making the response go over the context_window limit.

I set the num_output value to the max output token value of the model (16K tokens in the case of gpt-4o and mini), which might be a bit overkill but is the safest option. We could set it to maybe 4K or 2K.