### PR TITLE
fix: security label while renaming chat

### DIFF
--- a/django/chat/templates/chat/components/chat_security_label.html
+++ b/django/chat/templates/chat/components/chat_security_label.html
@@ -1,9 +1,7 @@
 
 {% load i18n %}
 
-<div class="dropdown"
-     id="chat-security-label-{{ chat.id }}"
-     {% if swap_oob %}hx-swap-oob="true"{% endif %}>
+<div class="dropdown">
   <button class="btn btn-none security-label-{{ chat.security_label.acronym }} security-label chat-security-label badge rounded-pill btn-dark"
           title="{{ chat.security_label }}"
           type="button"
@@ -12,13 +10,11 @@
   <ul class="dropdown-menu">
     <li class="dropdown-header">{% trans "Set security label" %}</li>
     {% for security_label in security_labels %}
- 
       <li>
         <button class="dropdown-item"
                 hx-get="{% url 'chat:set_security_label' chat.id security_label.id %}"
-                hx-target="closest div.dropdown"
+                hx-target="closest .dropdown"
                 hx-swap="outerHTML"
-                onclick="this.closest('div.dropdown').querySelector('button').innerHTML = '...';"
                 {% if security_label == chat.security_label %}disabled{% endif %}>
           <span class="security-label-{{ security_label.acronym }} security-label chat-security-label badge rounded-pill me-2">{{ security_label.acronym }}</span>
           <span class="me-1">{{ security_label }}</span>

--- a/django/chat/templates/chat/components/chat_security_label.html
+++ b/django/chat/templates/chat/components/chat_security_label.html
@@ -15,7 +15,7 @@
                 hx-get="{% url 'chat:set_security_label' chat.id security_label.id %}"
                 hx-target="closest .dropdown"
                 hx-swap="outerHTML"
-                {% if security_label == chat.security_label %}disabled{% endif %}>
+                {% if security_label.id == chat.security_label.id %}disabled{% endif %}>
           <span class="security-label-{{ security_label.acronym }} security-label chat-security-label badge rounded-pill me-2">{{ security_label.acronym }}</span>
           <span class="me-1">{{ security_label }}</span>
         </button>

--- a/django/chat/views.py
+++ b/django/chat/views.py
@@ -667,14 +667,7 @@ def rename_chat(request, chat_id, current_chat=None):
                 "swap_oob": True,
             }
             return render(request, "chat/components/chat_list_item.html", context)
-            # return render(
-            #     request,
-            #     "chat/components/chat_list_item.html",
-            #     {
-            #         "chat": chat,
-            #         "section_index": label_section_index(old_last_modification_date),
-            #     },
-            # )
+
         else:
             return render(
                 request,

--- a/django/chat/views.py
+++ b/django/chat/views.py
@@ -658,14 +658,23 @@ def rename_chat(request, chat_id, current_chat=None):
             old_last_modification_date = chat.last_modification_date
             chat.last_modification_date = timezone.now()
             chat.save()
-            return render(
-                request,
-                "chat/components/chat_list_item.html",
-                {
-                    "chat": chat,
-                    "section_index": label_section_index(old_last_modification_date),
-                },
-            )
+            # Re-fetch the chat to ensure we have fresh data
+            chat.refresh_from_db()
+            context = {
+                "chat": chat,
+                "security_labels": SecurityLabel.objects.all(),
+                "section_index": label_section_index(old_last_modification_date),
+                "swap_oob": True,
+            }
+            return render(request, "chat/components/chat_list_item.html", context)
+            # return render(
+            #     request,
+            #     "chat/components/chat_list_item.html",
+            #     {
+            #         "chat": chat,
+            #         "section_index": label_section_index(old_last_modification_date),
+            #     },
+            # )
         else:
             return render(
                 request,


### PR DESCRIPTION
-The **id** attribute was unnecessary since we're using HTMX's closest selector

-**hx-swap-oob** (out-of-band swap) was causing issues by trying to swap multiple elements at once

-Comparing by id is more reliable than object comparison so checking security_label.**id**==chat.security_label.**id**

-removed onclick() as the handler was changing button text to '...' during swap. **HTMX can handle the UI update automatically**. Removing onlcick() also prevents flickering/temporary text changes.

-removed **".div"** from **"closest div.dropdown"** as  _hx-target="closest .dropdown"_ dynamically finds the nearest parent with the dropdown class, so we don't need to assign an id to the div.