### PR TITLE
fix: toast message has chat update

### DIFF
--- a/django/librarian/views.py
+++ b/django/librarian/views.py
@@ -131,14 +131,24 @@ def modal_view(request, item_type=None, item_id=None, parent_id=None):
             )
             if form.is_valid():
                 form.save()
-                messages.success(
-                    request,
-                    (
-                        _("Folder updated successfully.")
-                        if item_id
-                        else _("Folder created successfully.")
-                    ),
-                )
+                if data_source.chat_id:
+                    messages.success(
+                        request,
+                        (
+                            _("Chat updated successfully.")
+                            if item_id
+                            else _("Chat created successfully.")
+                        ),
+                    )
+                else:
+                    messages.success(
+                        request,
+                        (
+                            _("Folder updated successfully.")
+                            if item_id
+                            else _("Folder created successfully.")
+                        ),
+                    )
                 selected_data_source = form.instance
                 item_id = selected_data_source.id
                 selected_library = selected_data_source.library

--- a/django/locale/translation/translations.json
+++ b/django/locale/translation/translations.json
@@ -2910,5 +2910,13 @@
     "Error submitting feedback.": {
         "fr": "",
         "fr_auto": "Erreur en soumettant des commentaires."
+    },
+    "Chat updated successfully.": {
+        "fr": "",
+        "fr_auto": "Le clavardage a été mis à jour avec succès."
+    },
+    "Chat created successfully.": {
+        "fr": "",
+        "fr_auto": "Chat créé avec succès."
     }
 }


### PR DESCRIPTION
When editing libraries, updating the "Chat Uploads" folder now shows the toast message "Chat updated successfully" instead of "Folder updated successfully".