### PR TITLE
fix: always use Azure OCR for PDFs (no PDFium)

### DIFF
--- a/django/librarian/tasks.py
+++ b/django/librarian/tasks.py
@@ -81,6 +81,10 @@ def process_document_helper(document, llm, pdf_method="default"):
     if not (url or file):
         raise ValueError("URL or file is required")
 
+    # PDFium is giving us issues with threading. For now, always use Azure OCR.
+    if pdf_method == "default":
+        pdf_method = "azure_read"
+
     if url:
         logger.info("Processing URL", url=url)
         base_url = (

--- a/django/librarian/templates/librarian/components/document_list.html
+++ b/django/librarian/templates/librarian/components/document_list.html
@@ -47,17 +47,8 @@
             <li>
               <a class="dropdown-item small"
                  href="#"
-                 hx-get="{% url 'librarian:data_source_start' selected_data_source.id 'default' 'all' %}">
-                <span>{% trans "Text only" %}</span>
-                <span class="text-muted">{% trans "(default, $)" %}</span>
-              </a>
-            </li>
-            <li>
-              <a class="dropdown-item small"
-                 href="#"
                  hx-get="{% url 'librarian:data_source_start' selected_data_source.id 'azure_read' 'all' %}">
-                <span>{% trans "PDF OCR" %}</span>
-                <span class="text-muted">{% trans "(more robust, $$)" %}</span>
+                <span>{% trans "Default" %}</span>
               </a>
             </li>
             <li>
@@ -65,7 +56,7 @@
                  href="#"
                  hx-get="{% url 'librarian:data_source_start' selected_data_source.id 'azure_layout' 'all' %}">
                 <span>{% trans "PDF layout & OCR" %}</span>
-                <span class="text-muted">{% trans "(best, $$$)" %}</span>
+                <span class="text-muted">{% trans "(best, $)" %}</span>
               </a>
             </li>
             <li>
@@ -77,17 +68,8 @@
             <li>
               <a class="dropdown-item small"
                  href="#"
-                 hx-get="{% url 'librarian:data_source_start' selected_data_source.id 'default' 'incomplete' %}">
-                <span>{% trans "Text only" %}</span>
-                <span class="text-muted">{% trans "(default, $)" %}</span>
-              </a>
-            </li>
-            <li>
-              <a class="dropdown-item small"
-                 href="#"
                  hx-get="{% url 'librarian:data_source_start' selected_data_source.id 'azure_read' 'incomplete' %}">
-                <span>{% trans "PDF OCR" %}</span>
-                <span class="text-muted">{% trans "(more robust, $$)" %}</span>
+                <span>{% trans "Default" %}</span>
               </a>
             </li>
             <li>
@@ -95,7 +77,7 @@
                  href="#"
                  hx-get="{% url 'librarian:data_source_start' selected_data_source.id 'azure_layout' 'incomplete' %}">
                 <span>{% trans "PDF layout & OCR" %}</span>
-                <span class="text-muted">{% trans "(best, $$$)" %}</span>
+                <span class="text-muted">{% trans "(best, $)" %}</span>
               </a>
             </li>
             <li>

--- a/django/librarian/templates/librarian/components/document_status.html
+++ b/django/librarian/templates/librarian/components/document_status.html
@@ -79,17 +79,8 @@
             <li>
               <a class="dropdown-item small"
                  href="#"
-                 hx-get="{% url 'librarian:document_start' document.id 'default' %}">
-                <span>{% trans "Text only" %}</span>
-                <span class="text-muted">{% trans "(default, $)" %}</span>
-              </a>
-            </li>
-            <li>
-              <a class="dropdown-item small"
-                 href="#"
                  hx-get="{% url 'librarian:document_start' document.id 'azure_read' %}">
-                <span>{% trans "PDF OCR" %}</span>
-                <span class="text-muted">{% trans "(more robust, $$)" %}</span>
+                <span>{% trans "Default" %}</span>
               </a>
             </li>
             <li>
@@ -97,7 +88,7 @@
                  href="#"
                  hx-get="{% url 'librarian:document_start' document.id 'azure_layout' %}">
                 <span>{% trans "PDF layout & OCR" %}</span>
-                <span class="text-muted">{% trans "(best, $$$)" %}</span>
+                <span class="text-muted">{% trans "(best, $)" %}</span>
               </a>
             </li>
           </ul>

--- a/django/locale/translation/translations.json
+++ b/django/locale/translation/translations.json
@@ -2910,5 +2910,13 @@
     "Error submitting feedback.": {
         "fr": "",
         "fr_auto": "Erreur en soumettant des commentaires."
+    },
+    "Default": {
+        "fr": "",
+        "fr_auto": "Défaut"
+    },
+    "(best, $)": {
+        "fr": "",
+        "fr_auto": "(meilleur, $)"
     }
 }

--- a/django/tests/librarian/test_librarian.py
+++ b/django/tests/librarian/test_librarian.py
@@ -188,7 +188,7 @@ def test_chat_data_source(client, all_apps_user):
     nodes = retriever.retrieve("What is this about?")
     assert len(nodes) > 0
 
-    assert document.pdf_method == "text only"
+    assert document.pdf_method == "OCR"
     assert document.truncated_text.startswith(document.extracted_text[:10])
     assert "$" in document.display_cost
 


### PR DESCRIPTION
PDFium is not thread safe which created issues during the stress test.
For now, we will just not use it at all.