### PR TITLE
fix: librarian bug

### DIFF
--- a/django/chat/forms.py
+++ b/django/chat/forms.py
@@ -150,6 +150,12 @@ class DataSourcesAutocomplete(HTMXAutoComplete):
                             Q(chat=chat) | Q(chat__messages__isnull=False)
                         ).distinct()
                     )
+                # Only show data sources that have Documents (data.documents.count() > 0)
+                data = [
+                    x
+                    for x in data
+                    if x.documents.count() > 0 or (x.chat and str(x.chat.id) == chat_id)
+                ]
         else:
             data = DataSource.objects.all()
         if search is not None:

--- a/django/chat/forms.py
+++ b/django/chat/forms.py
@@ -150,7 +150,7 @@ class DataSourcesAutocomplete(HTMXAutoComplete):
                             Q(chat=chat) | Q(chat__messages__isnull=False)
                         ).distinct()
                     )
-                # Only show data sources that have Documents (data.documents.count() > 0)
+                # Only show chats that have Documents (or are the current chat)
                 data = [
                     x
                     for x in data

--- a/django/librarian/templates/librarian/components/document_list.html
+++ b/django/librarian/templates/librarian/components/document_list.html
@@ -98,7 +98,13 @@
       {% include "librarian/components/items_list.html" with items=documents selected_item=selected_document listbox_label="documents-label" item_type="document" %}
     {% else %}
       <div class="text-center">
-        <em class="small">{% trans "No documents in this folder." %}</em>
+        <em class="small">
+          {% if selected_data_source and selected_data_source.chat_id %}
+            {% trans "No documents in this chat." %}
+          {% else %}
+            {% trans "No documents in this folder." %}
+          {% endif %}
+        </em>
       </div>
     {% endif %}
   {% endif %}

--- a/django/librarian/templates/librarian/components/list_item_inner.html
+++ b/django/librarian/templates/librarian/components/list_item_inner.html
@@ -28,8 +28,13 @@
            style="top: 1px"
            title="{% trans 'Personal library' %}"></i><span class="visually-hidden">{% trans "Personal library" %}</span>
       {% elif item_type == "data_source" %}
-        <span class="security-label-{{ item.security_label.acronym }} security-label badge rounded-pill"
-              title="{{ item.security_label }}">{{ item.security_label.acronym }}</span>
+        {% if item.chat %}
+          <span class="security-label-{{ item.chat.security_label.acronym }} security-label badge rounded-pill"
+                title="{{ item.chat.security_label }}">{{ item.chat.security_label.acronym }}</span>
+        {% else %}
+          <span class="security-label-{{ item.security_label.acronym }} security-label badge rounded-pill"
+                title="{{ item.security_label }}">{{ item.security_label.acronym }}</span>
+        {% endif %}
       {% elif item.status %}
         {% include "librarian/components/item_status_icon.html" %}
       {% endif %}

--- a/django/librarian/templates/librarian/forms/data_source.html
+++ b/django/librarian/templates/librarian/forms/data_source.html
@@ -11,61 +11,65 @@
   {# No delete URL needed when creating a new data source #}
 {% endif %}
 
-<form id="data-source-form" hx-post="{{ form_action_url }}">
-  {{ form.non_field_errors }}
-  <h6>
-    {% if form.instance.id %}
-      {% trans "Edit folder" %}
-    {% else %}
-      {% trans "Create folder" %}
-    {% endif %}
-  </h6>
-  {% csrf_token %}
-  {# For some reason I just CANNOT get {{ form.id }} to render, so I have to do this #}
-  <input type="hidden"
-         name="id"
-         value="{{ form.instance.id|default_if_none:'' }}">
-  {{ form.library }}
-  <div class="mb-3">
-    <label for="{{ form.name_en.id_for_label }}"
-           class="col-form-label col-form-label-sm">{% trans "Name (English)" %}</label>
-    {{ form.name_en.errors }}
-    {{ form.name_en }}
-  </div>
-  <div class="mb-3">
-    <label for="{{ form.name_fr.id_for_label }}"
-           class="col-form-label col-form-label-sm">{% trans "Name (French)" %}</label>
-    {{ form.name_fr.errors }}
-    {{ form.name_fr }}
-  </div>
-  <div class="mb-3">
-    <label for="{{ form.security_label.id_for_label }}"
-           class="col-form-label col-form-label-sm">{% trans "Security label " %}</label>
-    {{ form.security_label.errors }}
-    {{ form.security_label }}
-  </div>
-  <div class="mb-3">
-    <label for="{{ form.order.id_for_label }}"
-           class="col-form-label col-form-label-sm">{% trans "Order" %}</label>
-    {{ form.order.errors }}
-    {{ form.order }}
-  </div>
-  <div class="row">
-    <div class="col">
-      <button type="submit" class="btn btn-sm btn-primary me-1">{% trans "Save changes" %}</button>
-      <button type="button"
-              class="btn btn-sm btn-outline-secondary"
-              hx-get="{{ cancel_url }}">{% trans "Cancel" %}</button>
+{% if form.instance.id and form.instance.chat_id %}
+  <h6>{% trans "Chat uploads" %} - {{ form.instance.chat.title }}</h6>
+{% else %}
+  <form id="data-source-form" hx-post="{{ form_action_url }}">
+    {{ form.non_field_errors }}
+    <h6>
+      {% if form.instance.id %}
+        {% trans "Edit folder" %}
+      {% else %}
+        {% trans "Create folder" %}
+      {% endif %}
+    </h6>
+    {% csrf_token %}
+    {# For some reason I just CANNOT get {{ form.id }} to render, so I have to do this #}
+    <input type="hidden"
+           name="id"
+           value="{{ form.instance.id|default_if_none:'' }}">
+    {{ form.library }}
+    <div class="mb-3">
+      <label for="{{ form.name_en.id_for_label }}"
+             class="col-form-label col-form-label-sm">{% trans "Name (English)" %}</label>
+      {{ form.name_en.errors }}
+      {{ form.name_en }}
     </div>
-    {% if form.instance.id and form.deletable %}
-      <div class="col-auto">
+    <div class="mb-3">
+      <label for="{{ form.name_fr.id_for_label }}"
+             class="col-form-label col-form-label-sm">{% trans "Name (French)" %}</label>
+      {{ form.name_fr.errors }}
+      {{ form.name_fr }}
+    </div>
+    <div class="mb-3">
+      <label for="{{ form.security_label.id_for_label }}"
+             class="col-form-label col-form-label-sm">{% trans "Security label " %}</label>
+      {{ form.security_label.errors }}
+      {{ form.security_label }}
+    </div>
+    <div class="mb-3">
+      <label for="{{ form.order.id_for_label }}"
+             class="col-form-label col-form-label-sm">{% trans "Order" %}</label>
+      {{ form.order.errors }}
+      {{ form.order }}
+    </div>
+    <div class="row">
+      <div class="col">
+        <button type="submit" class="btn btn-sm btn-primary me-1">{% trans "Save changes" %}</button>
         <button type="button"
-                class="btn btn-sm btn-outline-danger"
-                hx-delete="{{ delete_url }}"
-                hx-confirm="{% trans 'DANGER: Are you sure you want to delete this folder? This action is permanent.' %}">
-          {% trans "Delete" %}
-        </button>
+                class="btn btn-sm btn-outline-secondary"
+                hx-get="{{ cancel_url }}">{% trans "Cancel" %}</button>
       </div>
-    {% endif %}
-  </div>
-</form>
+      {% if form.instance.id and form.deletable %}
+        <div class="col-auto">
+          <button type="button"
+                  class="btn btn-sm btn-outline-danger"
+                  hx-delete="{{ delete_url }}"
+                  hx-confirm="{% trans 'DANGER: Are you sure you want to delete this folder? This action is permanent.' %}">
+            {% trans "Delete" %}
+          </button>
+        </div>
+      {% endif %}
+    </div>
+  </form>
+{% endif %}

--- a/django/librarian/views.py
+++ b/django/librarian/views.py
@@ -131,24 +131,11 @@ def modal_view(request, item_type=None, item_id=None, parent_id=None):
             )
             if form.is_valid():
                 form.save()
-                if data_source.chat_id:
-                    messages.success(
-                        request,
-                        (
-                            _("Chat updated successfully.")
-                            if item_id
-                            else _("Chat created successfully.")
-                        ),
-                    )
+                if item_id:
+                    toast_message = _("Folder updated successfully.")
                 else:
-                    messages.success(
-                        request,
-                        (
-                            _("Folder updated successfully.")
-                            if item_id
-                            else _("Folder created successfully.")
-                        ),
-                    )
+                    toast_message = _("Folder created successfully.")
+                messages.success(request, toast_message)
                 selected_data_source = form.instance
                 item_id = selected_data_source.id
                 selected_library = selected_data_source.library

--- a/django/librarian/views.py
+++ b/django/librarian/views.py
@@ -275,6 +275,10 @@ def modal_view(request, item_type=None, item_id=None, parent_id=None):
     else:
         poll_url = None
 
+    # Don't show chats that don't have any Q&A documents
+    if data_sources and selected_library.is_personal_library:
+        data_sources = [ds for ds in data_sources if ds.documents.count() > 0]
+
     context = {
         "libraries": libraries,
         "selected_library": selected_library,

--- a/django/locale/translation/translations.json
+++ b/django/locale/translation/translations.json
@@ -3390,5 +3390,9 @@
     "Click the sun or moon icon to switch between dark and light themes.": {
         "fr": "",
         "fr_auto": "Cliquez sur l’icône du soleil ou de la lune pour basculer entre les thèmes sombres et clairs."
+    },
+    "No documents in this chat.": {
+        "fr": "",
+        "fr_auto": "Aucun document dans ce clavardage."
     }
 }


### PR DESCRIPTION
Bug introduced in #302 
- creating/updating any data source except chat uploads would result in 500 error

Another way to solve the issue, which I pursued here:
- don't allow users to modify the chat upload folders from within librarian

A couple related improvements:
- only show chats that have Q&A uploads in librarian
- only list chats that have Q&A uploads in the "Select chat" autocomplete widget (in Q&A settings sidebar)
  - plus "This chat" always shown too, regardless of whether it has any Q&A uploads yet.