### PR TITLE
fix: compile translation files during Docker build

### DIFF
--- a/django/Dockerfile
+++ b/django/Dockerfile
@@ -36,4 +36,7 @@ RUN mkdir -p $TIKTOKEN_CACHE_DIR
 # Run the tiktoken caching script
 RUN python /django/cache_tiktoken.py
 
+# Compile the translation files
+RUN python /django/manage.py load_app_localization
+
 CMD ["daphne", "--bind", "0.0.0.0", "--port", "8000", "otto.asgi:application"]


### PR DESCRIPTION
Localization do not occur in DEV. I've included them in the build instead as they shouldn't really change anyways.