### PR TITLE
fix: pypdfium lock

### DIFF
--- a/django/librarian/tasks.py
+++ b/django/librarian/tasks.py
@@ -81,10 +81,6 @@ def process_document_helper(document, llm, pdf_method="default"):
     if not (url or file):
         raise ValueError("URL or file is required")
 
-    # PDFium is giving us issues with threading. For now, always use Azure OCR.
-    if pdf_method == "default":
-        pdf_method = "azure_read"
-
     if url:
         logger.info("Processing URL", url=url)
         base_url = (

--- a/django/librarian/tasks.py
+++ b/django/librarian/tasks.py
@@ -152,7 +152,7 @@ def process_document_helper(document, llm, pdf_method="default"):
     vector_store_index.delete_ref_doc(document_uuid, delete_from_docstore=True)
     # Insert new nodes in batches
     batch_size = 16
-    for i in tqdm(range(0, len(nodes), batch_size)):
+    for i in range(0, len(nodes), batch_size):
         if i > 0:
             percent_complete = i / len(nodes) * 100
             if current_task:

--- a/django/librarian/templates/librarian/components/document_list.html
+++ b/django/librarian/templates/librarian/components/document_list.html
@@ -47,8 +47,17 @@
             <li>
               <a class="dropdown-item small"
                  href="#"
+                 hx-get="{% url 'librarian:data_source_start' selected_data_source.id 'default' 'all' %}">
+                <span>{% trans "Text only" %}</span>
+                <span class="text-muted">{% trans "(default, $)" %}</span>
+              </a>
+            </li>
+            <li>
+              <a class="dropdown-item small"
+                 href="#"
                  hx-get="{% url 'librarian:data_source_start' selected_data_source.id 'azure_read' 'all' %}">
-                <span>{% trans "Default" %}</span>
+                <span>{% trans "PDF OCR" %}</span>
+                <span class="text-muted">{% trans "(more robust, $$)" %}</span>
               </a>
             </li>
             <li>
@@ -56,7 +65,7 @@
                  href="#"
                  hx-get="{% url 'librarian:data_source_start' selected_data_source.id 'azure_layout' 'all' %}">
                 <span>{% trans "PDF layout & OCR" %}</span>
-                <span class="text-muted">{% trans "(best, $)" %}</span>
+                <span class="text-muted">{% trans "(best, $$$)" %}</span>
               </a>
             </li>
             <li>
@@ -68,8 +77,17 @@
             <li>
               <a class="dropdown-item small"
                  href="#"
+                 hx-get="{% url 'librarian:data_source_start' selected_data_source.id 'default' 'incomplete' %}">
+                <span>{% trans "Text only" %}</span>
+                <span class="text-muted">{% trans "(default, $)" %}</span>
+              </a>
+            </li>
+            <li>
+              <a class="dropdown-item small"
+                 href="#"
                  hx-get="{% url 'librarian:data_source_start' selected_data_source.id 'azure_read' 'incomplete' %}">
-                <span>{% trans "Default" %}</span>
+                <span>{% trans "PDF OCR" %}</span>
+                <span class="text-muted">{% trans "(more robust, $$)" %}</span>
               </a>
             </li>
             <li>
@@ -77,7 +95,7 @@
                  href="#"
                  hx-get="{% url 'librarian:data_source_start' selected_data_source.id 'azure_layout' 'incomplete' %}">
                 <span>{% trans "PDF layout & OCR" %}</span>
-                <span class="text-muted">{% trans "(best, $)" %}</span>
+                <span class="text-muted">{% trans "(best, $$$)" %}</span>
               </a>
             </li>
             <li>

--- a/django/librarian/templates/librarian/components/document_status.html
+++ b/django/librarian/templates/librarian/components/document_status.html
@@ -79,8 +79,17 @@
             <li>
               <a class="dropdown-item small"
                  href="#"
+                 hx-get="{% url 'librarian:document_start' document.id 'default' %}">
+                <span>{% trans "Text only" %}</span>
+                <span class="text-muted">{% trans "(default, $)" %}</span>
+              </a>
+            </li>
+            <li>
+              <a class="dropdown-item small"
+                 href="#"
                  hx-get="{% url 'librarian:document_start' document.id 'azure_read' %}">
-                <span>{% trans "Default" %}</span>
+                <span>{% trans "PDF OCR" %}</span>
+                <span class="text-muted">{% trans "(more robust, $$)" %}</span>
               </a>
             </li>
             <li>
@@ -88,7 +97,7 @@
                  href="#"
                  hx-get="{% url 'librarian:document_start' document.id 'azure_layout' %}">
                 <span>{% trans "PDF layout & OCR" %}</span>
-                <span class="text-muted">{% trans "(best, $)" %}</span>
+                <span class="text-muted">{% trans "(best, $$$)" %}</span>
               </a>
             </li>
           </ul>

--- a/django/otto/utils/common.py
+++ b/django/otto/utils/common.py
@@ -1,8 +1,11 @@
+from threading import Lock
 from urllib.parse import quote, urlparse
 
 from django.conf import settings
 
 import tldextract
+
+pdfium_lock = Lock()
 
 
 def file_size_to_string(filesize):

--- a/django/requirements.txt
+++ b/django/requirements.txt
@@ -50,7 +50,7 @@ markdownify==0.13.1
 Markdown==3.7
 bleach==6.1.0
 newspaper3k==0.2.8
-pypdfium2==4.30.0
+pypdfium2==4.30.1
 filetype==1.2.0
 docxtpl==0.19.1
 html2docx==1.6.0

--- a/django/tests/librarian/test_librarian.py
+++ b/django/tests/librarian/test_librarian.py
@@ -188,7 +188,7 @@ def test_chat_data_source(client, all_apps_user):
     nodes = retriever.retrieve("What is this about?")
     assert len(nodes) > 0
 
-    assert document.pdf_method == "OCR"
+    assert document.pdf_method == "text only"
     assert document.truncated_text.startswith(document.extracted_text[:10])
     assert "$" in document.display_cost
 


### PR DESCRIPTION
Also reverts the removal of Pdfium as default mode for Q&A loading.

Needs to be tested in sandbox with multiple users to ensure no Pdfium errors.