### PR TITLE
fix: htmx redirect checks

### DIFF
--- a/django/otto/utils/common.py
+++ b/django/otto/utils/common.py
@@ -3,6 +3,9 @@ from threading import Lock
 from urllib.parse import quote, urlparse
 
 from django.conf import settings
+from django.http import HttpResponse
+from django.shortcuts import redirect
+from django.urls import reverse
 
 import tldextract
 
@@ -115,3 +118,14 @@ def get_tld_extractor():
         suffix_list_urls=[os.path.join(settings.BASE_DIR, "effective_tld_names.dat")],
         cache_dir=os.path.join(settings.BASE_DIR, "tld_cache"),
     )
+
+
+def robust_redirect(request, redirect_url):
+    """
+    Checks if HTMX request and redirects accordingly
+    """
+    if request.headers.get("HX-Request"):
+        response = HttpResponse(status=200)
+        response["HX-Redirect"] = redirect_url
+        return response
+    return redirect(redirect_url)

--- a/django/otto/utils/decorators.py
+++ b/django/otto/utils/decorators.py
@@ -11,6 +11,7 @@ from structlog import get_logger
 
 from otto.models import App, Notification
 from otto.rules import ADMINISTRATIVE_PERMISSIONS
+from otto.utils.common import robust_redirect
 
 logger = get_logger(__name__)
 
@@ -22,7 +23,7 @@ def app_access_required(app_handle):
         def wrapper(request, *args, **kwargs):
             if not request.user.is_authenticated:
                 logger.info("User is not authenticated", category="security")
-                return redirect(reverse("index"))
+                return robust_redirect(request, reverse("index"))
 
             app = App.objects.get(handle=app_handle)
             if not request.user.has_perm("otto.access_app", app):
@@ -37,7 +38,7 @@ def app_access_required(app_handle):
                     text=_("You are not authorized to access") + f" {app.name}",
                     category="error",
                 )
-                return redirect(reverse("index"))
+                return robust_redirect(request, reverse("index"))
 
             return func(request, *args, **kwargs)
 
@@ -100,7 +101,7 @@ def permission_required(
                         text=_(f"Unauthorized access of URL:") + f" {request.path}",
                         category="error",
                     )
-                    return redirect(reverse("index"))
+                    return robust_redirect(request, reverse("index"))
             else:
                 # User has all required permissions -- allow the view to execute
                 if bool(ADMINISTRATIVE_PERMISSIONS.intersection(perms)):


### PR DESCRIPTION
Previously some middleware/decorator checks would return a redirected view inside a HTMX request. This resulted in a "Otto within Otto" swap inside e.g. a modal that was making a not-permitted HTMX request.