### PR TITLE
fix: tldextract file path

### DIFF
--- a/django/otto/utils/common.py
+++ b/django/otto/utils/common.py
@@ -115,7 +115,9 @@ def get_tld_extractor():
     Returns a tldextract.TLDExtract instance with the default suffix list
     """
     return tldextract.TLDExtract(
-        suffix_list_urls=[os.path.join(settings.BASE_DIR, "effective_tld_names.dat")],
+        suffix_list_urls=[
+            "file://" + os.path.join(settings.BASE_DIR, "effective_tld_names.dat")
+        ],
         cache_dir=os.path.join(settings.BASE_DIR, "tld_cache"),
     )
 


### PR DESCRIPTION
To test:
* Delete your local django/tld_cache directory
* Restart django
* Add a URL to Q&A mode (bad or good url)
* Ensure tld_cache directory is created with no errors in the django logs