### PR TITLE
chore: let admins skip tours, click to close "overlaid" sidebars

### DIFF
--- a/django/chat/static/chat/js/scripts.js
+++ b/django/chat/static/chat/js/scripts.js
@@ -182,6 +182,22 @@ function toggleAriaSelected(mode) {
   });
 }
 
+
+// Close the sidebars that are in "overlay mode" when clicking outside of them
+document.addEventListener('click', function (e) {
+  let clicked_element = e.target;
+  let left_sidebar = document.querySelector('#left-sidebar');
+  let right_sidebar = document.querySelector('#right-sidebar');
+  if (!(clicked_element.closest(".chat-sidebar-toggle") || left_sidebar.contains(clicked_element) || right_sidebar.contains(clicked_element))) {
+    if (window.getComputedStyle(left_sidebar).position === "absolute" && !left_sidebar.classList.contains("hidden")) {
+      closeSidebar("left-sidebar");
+    }
+    if (window.getComputedStyle(right_sidebar).position === "absolute" && !right_sidebar.classList.contains("hidden")) {
+      closeSidebar("right-sidebar");
+    }
+  }
+});
+
 // Some resizing hacks to make the prompt form the same width as the messages
 function resizePromptContainer() {
   let chatContainer = document.querySelector("#chat-container");

--- a/django/chat/views.py
+++ b/django/chat/views.py
@@ -249,7 +249,9 @@ def chat(request, chat_id):
         "chat_history_sections": get_chat_history_sections(user_chats),
         "has_tour": True,
         "tour_name": _("AI Assistant"),
-        "force_tour": not request.user.ai_assistant_tour_completed,
+        "force_tour": not (
+            request.user.ai_assistant_tour_completed or request.user.is_admin
+        ),
         "start_tour": request.GET.get("start_tour") == "true",
     }
     return render(request, "chat/chat.html", context=context)

--- a/django/otto/views.py
+++ b/django/otto/views.py
@@ -115,7 +115,9 @@ def index(request):
             "hide_breadcrumbs": True,
             "categorized_features": get_categorized_features(request.user),
             "has_tour": True,
-            "force_tour": not request.user.homepage_tour_completed,
+            "force_tour": not (
+                request.user.homepage_tour_completed or request.user.is_admin
+            ),
         },
     )
 


### PR DESCRIPTION
https://dev.azure.com/BusinessAnalyticsCentre/BAC%20Agile/_workitems/edit/3197

Added flags to the force_tour checks to see if the user is an admin, and skip the tours if so. Also added eventListeners to chat windows so that sidebars are hidden when they're in "overlay mode" (i.e. when window is sufficiently narrow)