### PR TITLE
fix: remove wget command for GoC root certificate installation and configure Python to use system CA bundle

### DIFF
--- a/django/Dockerfile
+++ b/django/Dockerfile
@@ -15,15 +15,22 @@ RUN apt-get update \
     && rm -rf /var/lib/apt/lists/* \
     && rm -rf /var/cache/apt/archives/*
 
-# Download and install the GoC root certificate using wget
-# TODO: Remove the header and replace the IP with the domain name when the host no longer resets the connection from the secondary IP
-RUN wget -q --header="Host: pki-icp.canada.ca" http://167.43.15.18/aia/GoC-GdC-Root-A.crt -O /usr/local/share/ca-certificates/GoC-GdC-Root-A.crt \
+# Copy GoC Root CA before Python certificate configuration
+COPY GoC-GdC-Root-A.crt /usr/local/share/ca-certificates/
+RUN chmod 644 /usr/local/share/ca-certificates/GoC-GdC-Root-A.crt \
     && update-ca-certificates
 
 COPY requirements*.txt /tmp/pip-tmp/
 RUN pip3 --disable-pip-version-check --no-cache-dir install \
     -r /tmp/pip-tmp/requirements.txt \
     && rm -rf /tmp/pip-tmp
+
+# Ensure Python uses the system CA bundle instead of certifi’s,
+# so that any custom or organization CA certificates (like the GoC root CA)
+# injected at runtime are trusted by all Python HTTPS clients.
+RUN rm -f /usr/local/lib/python3.11/site-packages/certifi/cacert.pem && \
+    ln -s /etc/ssl/certs/ca-certificates.crt /usr/local/lib/python3.11/site-packages/certifi/cacert.pem && \
+    sed -i 's/return _certifi_where()/return "\/etc\/ssl\/certs\/ca-certificates.crt"/' /usr/local/lib/python3.11/site-packages/certifi/core.py
 
 COPY . /django
 


### PR DESCRIPTION
- Fixed the SSL Cert Verification Error: `[SSL: CERTIFICATE_VERIFY_FAILED] certificate verify failed: self signed certificate in certificate chain`
  - Removed wget command from Dockerfile
  - Copy cert from local VM and chmod before updating ca certs
  - Configured Python to use system CA bundle instead of certifi
