### PR TITLE
fix: robustness to existing bad SavedFile

### DIFF
--- a/django/librarian/models.py
+++ b/django/librarian/models.py
@@ -529,8 +529,6 @@ class SavedFile(models.Model):
         if self.chat_files.exists() or self.documents.exists():
             logger.info(f"File {self.file.name} has associated objects; not deleting")
             return
-        if self.file:
-            self.file.delete(False)
         self.delete()
 
 

--- a/django/librarian/models.py
+++ b/django/librarian/models.py
@@ -529,6 +529,8 @@ class SavedFile(models.Model):
         if self.chat_files.exists() or self.documents.exists():
             logger.info(f"File {self.file.name} has associated objects; not deleting")
             return
+        if self.file:
+            self.file.delete(True)
         self.delete()
 
 

--- a/django/librarian/views.py
+++ b/django/librarian/views.py
@@ -1,4 +1,4 @@
-# views.py
+import os
 from dataclasses import dataclass
 
 from django.contrib import messages
@@ -488,13 +488,16 @@ def upload(request, data_source_id):
     <input type="file" name="file" id="document-file-input" multiple>
     """
     bind_contextvars(feature="librarian")
+    existing_document_count = 0
 
     for file in request.FILES.getlist("file"):
         # Check if the file is already stored on the server
         file_hash = generate_hash(file.read())
-        file_exists = SavedFile.objects.filter(sha256_hash=file_hash).exists()
-        if file_exists:
-            file_obj = SavedFile.objects.filter(sha256_hash=file_hash).first()
+        # Further check that the file is on disk
+        file_obj = SavedFile.objects.filter(sha256_hash=file_hash).first()
+        file_exists = file_obj is not None
+        is_good_file = file_exists and os.path.exists(file_obj.file.path)
+        if is_good_file:
             logger.info(
                 f"Found existing SavedFile for {file.name}", saved_file_id=file_obj.id
             )
@@ -506,11 +509,13 @@ def upload(request, data_source_id):
             ).first()
             # Skip if filename and hash are the same, but reprocess if ERROR status
             if existing_document:
+                existing_document_count += 1
                 if existing_document.status == "ERROR":
                     existing_document.process()
                 continue
         else:
-            file_obj = SavedFile.objects.create(content_type=file.content_type)
+            if not file_exists:
+                file_obj = SavedFile.objects.create(content_type=file.content_type)
             file_obj.file.save(file.name, file)
             file_obj.generate_hash()
 
@@ -520,6 +525,12 @@ def upload(request, data_source_id):
         document.process()
     # Update the modal with the new documents
     request.method = "GET"
+    if existing_document_count > 0:
+        messages.warning(
+            request,
+            _("%(count)d identical document(s) already exist in the library. ")
+            % {"count": existing_document_count},
+        )
     return modal_view(request, item_type="data_source", item_id=data_source_id)
 
 

--- a/django/locale/translation/translations.json
+++ b/django/locale/translation/translations.json
@@ -3954,5 +3954,9 @@
     "Otto can be accessed via the URL <a href=\"%(site_url)s\">%(site_url)s</a>. You must be connected to the Justice network.": {
         "fr": "",
         "fr_auto": "Otto est accessible via l’URL <a href=\"%(site_url)s\">%(site_url)s</a>. Vous devez être connecté au réseau de la justice."
+    },
+    "%(count)d identical document(s) already exist in the library. ": {
+        "fr": "",
+        "fr_auto": "%(count)d Documents(s) identiques(s) existent(s) déjà dans la bibliothèque. "
     }
 }


### PR DESCRIPTION
When uploading a file & checking for existing SavedFile with matching hash, also check if file exists on disk.

* if matching hash SavedFile exists with no file on disk, fix it
* if matching hash SavedFile exists and has a file on disk, use it.
* if no matching hash, create a new SavedFile