### PR TITLE
fix: adjusted drag events for Firefox

### DIFF
--- a/django/chat/templates/chat/components/file_dropzone.html
+++ b/django/chat/templates/chat/components/file_dropzone.html
@@ -31,20 +31,25 @@
   function handleDragEnter(e) {
     // make sure we're dragging a file
     var dt = (e && e.dataTransfer);
-    var isFile = (dt && dt.types && dt.types.length == 1 && dt.types[0] == "Files");
-    if (isFile) {
-      // check if the mode is "chat"; if so, switch to QA mode
-      if (document.querySelector('#id_mode').value == 'chat') {
-        handleModeChange('qa');
-      }
-      showOverlay();
+    if (!dt) {
+      return;
     }
+    // required to create an array for Firefox 
+    Array.from(dt.types)?.forEach((type) => {
+      if (type === "Files") {
+        // check if the mode is "chat"; if so, switch to QA mode
+        if (document.querySelector('#id_mode').value == 'chat') {
+          handleModeChange('qa');
+        }
+        showOverlay();
+      }
+    });    
   }
 
   function handleDragLeave(e) {
-    // was our dragleave off the page?
-    if (e && e.pageX == 0 && e.pageY == 0) {
-      // then hide the overlay
+    // Check if the related target is not a child of the drop zone
+    const dropZoneElement = document.querySelector('#file-dropzone');
+    if (!e.relatedTarget || !dropZoneElement.contains(e.relatedTarget)) {
       hideOverlay();
     }
   }

--- a/django/chat/templates/chat/components/upload_form.html
+++ b/django/chat/templates/chat/components/upload_form.html
@@ -1,4 +1,3 @@
-
 <form id="chat-upload-form"
       method="post"
       enctype="multipart/form-data"
@@ -22,7 +21,13 @@
       return file.classList.contains("dff-upload-success") || file.classList.contains("dff-upload-fail");
     });
     if (allDone) {
-      form.dispatchEvent(new Event('submit'));
+      // Use htmx directly instead of native form submission
+      htmx.trigger(form, 'htmx:beforeRequest');
+      htmx.ajax('POST', form.getAttribute('hx-post'), {
+        source: form,
+        target: form.getAttribute('hx-target'),
+        swap: form.getAttribute('hx-swap')
+      });
       upload_message.classList.add("submitting");
     }
     hideIfNoFiles();


### PR DESCRIPTION
- Htmx code not trigger in Firefox after drop event. Native submit was triggered instead.
- Adjusted drag handler's logic for Firefox.