### PR TITLE
fix: options sidebar / preset loading bugs

### DIFF
--- a/django/chat/static/chat/js/scripts.js
+++ b/django/chat/static/chat/js/scripts.js
@@ -310,12 +310,10 @@ document.addEventListener("keydown", function (event) {
 // Accordion swapped
 document.addEventListener("htmx:afterSwap", function (event) {
   if (event.detail?.target?.id !== "options-accordion") return;
-  console.log("Accordion swapped");
   afterAccordionSwap();
 });
 document.addEventListener("htmx:oobAfterSwap", function (event) {
   if (event.detail?.target?.id !== "options-accordion") return;
-  console.log("Accordion swapped OOB");
   afterAccordionSwap();
 });
 

--- a/django/chat/static/chat/js/scripts.js
+++ b/django/chat/static/chat/js/scripts.js
@@ -498,13 +498,17 @@ function updateQaModal() {
   // console.log('Updating QA modal');
   const qa_modal_elements = document.querySelectorAll('#advanced-qa-modal [data-inputname]');
   qa_modal_elements.forEach((modal_element) => {
-    // Dataset attributes are lowercased
     const hidden_input_name = modal_element.dataset.inputname;
     const hidden_field_element = document.querySelector(`input[name="${hidden_input_name}"]`);
-    // console.log(hidden_input_name, hidden_field_element);
     if (hidden_field_element) {
-      modal_element.value = hidden_field_element.value;
+      if (modal_element.type === "checkbox") {
+        modal_element.checked = hidden_field_element.value.toLowerCase() === "true";
+        modal_element.value = modal_element.checked ? "true" : "false";
+      } else {
+        modal_element.value = hidden_field_element.value;
+      }
     }
+    toggleGranularOptions(document.getElementById('qa_answer_mode-modal').value);
   });
 };
 function updateQaHiddenField(modal_element) {
@@ -520,8 +524,6 @@ function updateQaHiddenField(modal_element) {
 
 function toggleGranularOptions(value) {
   var gran_slider = document.getElementById('qa_granularity_slider');
-  var gran = document.getElementById('qa_granularity-modal');
-
   var pruning_toggle = document.getElementById('qa_pruning');
 
   if (value === 'per-source') {
@@ -529,11 +531,8 @@ function toggleGranularOptions(value) {
     pruning_toggle.style.display = '';
   } else {
     gran_slider.style.display = 'none';
-    gran.value = 768; // Reset slider value to 768 when "combined" is selected
     pruning_toggle.style.display = 'none';
   }
-
-  updateQaHiddenField(gran);
 }
 
 

--- a/django/chat/templates/chat/components/chat_options_accordion.html
+++ b/django/chat/templates/chat/components/chat_options_accordion.html
@@ -1,6 +1,11 @@
 <div class="accordion accordion-flush border-top"
      id="options-accordion"
-     {% if swap %}hx-swap-oob="true"{% endif %}>
+     {% if swap %}hx-swap-oob="true"{% endif %}
+     data-preset-loaded="{{ preset_loaded }}"
+     data-swap="{{ swap }}"
+     data-trigger-library-change="{{ trigger_library_change }}"
+     data-mode="{{ options_form.mode.value }}"
+     data-prompt="{{ prompt }}">
   {% include 'chat/components/options_1_chat_with_ai.html' with options_section_id='chat' %}
   {% include 'chat/components/options_4_qa.html' with options_section_id='qa' %}
   {% include 'chat/components/options_2_summarize.html' with options_section_id='summarize' %}
@@ -10,25 +15,6 @@
 {% include "chat/components/chat_label_script.html" %}
 
 <script>
-  (function (){
-    {% if prompt %}document.querySelector('#chat-prompt').value = '{{ prompt }}';{% endif %}
-    if ("{{ preset_loaded }}" === "true" || "{{ swap }}" === "true") {
-      let mode = "{{ options_form.mode.value }}";
-      let is_preset_loaded = ("{{ preset_loaded }}" === "true");
-      handleModeChange(mode, null, is_preset_loaded);
-      const qa_mode_value = document.getElementById('id_qa_mode').value;
-      switchToDocumentScope();
-      // Update the advanced settings RAG options visibility
-      toggleRagOptions(qa_mode_value);
-      setTimeout(updateQaSourceForms, 100);
-    } else if ("{{ trigger_library_change }}" === "true") {
-      // This function calls updateQaSourceForms, so no need to call it twice
-      resetQaAutocompletes();
-    } else {
-      updateQaSourceForms();
-    }
-  })();
-
   updateLibraryModalButton();
   updateAutocompleteLibraryid('id_qa_data_sources__textinput');
   updateAutocompleteLibraryid('id_qa_documents__textinput');

--- a/django/chat/templates/chat/components/chat_tour_steps.html
+++ b/django/chat/templates/chat/components/chat_tour_steps.html
@@ -47,7 +47,7 @@ let tourSteps = [
       onNextClick: async () => {
         document.querySelector("button.driver-popover-next-btn").disabled = true;
         // Check if there are any div.message-outer elements
-        let messages_exist = document.querySelectorAll("div.message-outer").length > 0;
+        let messages_exist = document.querySelectorAll("div.message-outer").length > 1;
         if (!messages_exist) {
           // If no messages exist, send a message
           const chatInput = document.querySelector("#chat-prompt");

--- a/django/chat/templates/chat/modals/presets/card.html
+++ b/django/chat/templates/chat/modals/presets/card.html
@@ -32,6 +32,7 @@
        data-bs-dismiss="modal"
        href="#"
        hx-post="{% url 'chat:chat_options' chat_id=chat_id action='load_preset' preset_id=preset.id %}"
-       hx-target="#options-accordion">{% trans "Load settings" %}</a>
+       hx-target="#options-accordion"
+       hx-swap="outerHTML">{% trans "Load settings" %}</a>
   </div>
 </li>


### PR DESCRIPTION
When loading a preset, it appeared to work, but the old chat options were being saved again right after loading - thus making the loaded preset NOT actually function.