### PR TITLE
fix: errors and successes counted properly from .zip files

### DIFF
--- a/django/chat/responses.py
+++ b/django/chat/responses.py
@@ -465,7 +465,7 @@ def qa_response(chat, response_message, switch_mode=False):
             ]
             error_docs_joined = "\n\n - " + "\n\n - ".join(doc_errors)
             error_string += error_docs_joined
-            if len(error_documents) != len(files):
+            if num_completed_documents > 0:
                 error_string += f"\n\n{num_completed_documents} "
                 error_string += _("new document(s) ready for Q&A.")
             yield error_string


### PR DESCRIPTION
The old logic to display the "files ready for Q&A" message broke in the presence of _exactly one_ corrupted file in a .zip. This is because the logic relied on comparing the number of error docs to the number of _files_, and a .zip counts as only one file despite resulting in multiple docs. I've made the logic more direct, but can't say with confidence whether there's a good reason _not_ to do it this way.