### PR TITLE
fix: add cl100k_base encoding to tiktoken cache

### DIFF
--- a/django/cache_tiktoken.py
+++ b/django/cache_tiktoken.py
@@ -17,3 +17,5 @@ for model in models:
 
 # All the models we use, including gpt-4.1 (currently not in tiktoken) use o200k_base
 tiktoken.get_encoding("o200k_base")
+# Embedding models use cl100k_base
+tiktoken.get_encoding("cl100k_base")


### PR DESCRIPTION
Hopefully this will fix the following error (directly caused by line 310 of markdown_splitter.py
`tokenizer = tiktoken.get_encoding("cl100k_base")`

```
urllib3.exceptions.MaxRetryError: HTTPSConnectionPool(host='openaipublic.blob.core.windows.net', port=443): Max retries exceeded with url: /encodings/cl100k_base.tiktoken (Caused by SSLError(SSLEOFError(8, '[SSL: UNEXPECTED_EOF_WHILE_READING] EOF occurred in violation of protocol (_ssl.c:1016)')))
 
During handling of the above exception, another exception occurred:
 
Traceback (most recent call last):
  File "/django/manage.py", line 23, in <module>
    main()
  File "/django/manage.py", line 19, in main
    execute_from_command_line(sys.argv)
  File "/usr/local/lib/python3.11/site-packages/django/core/management/__init__.py", line 442, in execute_from_command_line
    utility.execute()
  File "/usr/local/lib/python3.11/site-packages/django/core/management/__init__.py", line 436, in execute
    self.fetch_command(subcommand).run_from_argv(self.argv)
  File "/usr/local/lib/python3.11/site-packages/django/core/management/base.py", line 413, in run_from_argv
    self.execute(*args, **cmd_options)
  File "/usr/local/lib/python3.11/site-packages/django/core/management/base.py", line 459, in execute
    output = self.handle(*args, **options)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.11/site-packages/django_extensions/management/utils.py", line 65, in inner
    ret = func(self, *args, **kwargs)
          ^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/django/otto/management/commands/reset_app_data.py", line 93, in handle
    self.reset_libraries("library_mini.yaml")
  File "/django/otto/management/commands/reset_app_data.py", line 196, in reset_libraries
    library_instance = Library.objects.create(**library_fields)
                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/django/librarian/models.py", line 75, in create
    library.reset()
  File "/django/librarian/models.py", line 188, in reset
    llm.get_retriever(self.uuid_hex).retrieve("?")
    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/django/chat/llm.py", line 232, in get_retriever
    pg_idx = self.get_index(vector_store_table, hnsw=hnsw)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/django/chat/llm.py", line 280, in get_index
    idx = VectorStoreIndex.from_vector_store(
          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.11/site-packages/llama_index/core/indices/vector_store/base.py", line 103, in from_vector_store
    return cls(
           ^^^^
  File "/usr/local/lib/python3.11/site-packages/llama_index/core/indices/vector_store/base.py", line 77, in __init__
    super().__init__(
  File "/usr/local/lib/python3.11/site-packages/llama_index/core/indices/base.py", line 86, in __init__
    self._transformations = transformations or Settings.transformations
                                               ^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.11/site-packages/llama_index/core/settings.py", line 238, in transformations
    self._transformations = [self.node_parser]
                             ^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.11/site-packages/llama_index/core/settings.py", line 141, in node_parser
    self._node_parser = SentenceSplitter()
                        ^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.11/site-packages/llama_index/core/node_parser/text/sentence.py", line 104, in __init__
    self._tokenizer = tokenizer or get_tokenizer()
                                   ^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.11/site-packages/llama_index/core/utils.py", line 161, in get_tokenizer
    enc = tiktoken.encoding_for_model(model_name)
          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.11/site-packages/tiktoken/model.py", line 110, in encoding_for_model
    return get_encoding(encoding_name_for_model(model_name))
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.11/site-packages/tiktoken/registry.py", line 86, in get_encoding
    enc = Encoding(**constructor())
                     ^^^^^^^^^^^^^
  File "/usr/local/lib/python3.11/site-packages/tiktoken_ext/openai_public.py", line 76, in cl100k_base
    mergeable_ranks = load_tiktoken_bpe(
                      ^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.11/site-packages/tiktoken/load.py", line 148, in load_tiktoken_bpe
    contents = read_file_cached(tiktoken_bpe_file, expected_hash)
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.11/site-packages/tiktoken/load.py", line 63, in read_file_cached
    contents = read_file(blobpath)
               ^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.11/site-packages/tiktoken/load.py", line 22, in read_file
    resp = requests.get(blobpath)
           ^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.11/site-packages/requests/api.py", line 73, in get
    return request("get", url, params=params, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.11/site-packages/requests/api.py", line 59, in request
    return session.request(method=method, url=url, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.11/site-packages/requests/sessions.py", line 589, in request
    resp = self.send(prep, **send_kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.11/site-packages/requests/sessions.py", line 703, in send
    r = adapter.send(request, **kwargs)
        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.11/site-packages/requests/adapters.py", line 698, in send
    raise SSLError(e, request=request)
requests.exceptions.SSLError: HTTPSConnectionPool(host='openaipublic.blob.core.windows.net', port=443): Max retries exceeded with url: /encodings/cl100k_base.tiktoken (Caused by SSLError(SSLEOFError(8, '[SSL: UNEXPECTED_EOF_WHILE_READING] EOF occurred in violation of protocol (_ssl.c:1016)')))
Error: Reset app data failed
command terminated with exit code 1
```