### PR TITLE
chore: update .env.example; robustness fixes

### DIFF
--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -53,7 +53,7 @@ jobs:
       AZURE_COGNITIVE_SERVICE_KEY: ${{secrets.AZURE_COGNITIVE_SERVICE_KEY}}
       DJANGODB_HOST: postgres-service
       VECTORDB_HOST: postgres-service
-      LOG_LEVEL: ERROR      
+      LOG_LEVEL: ERROR
     steps:
     - uses: actions/checkout@v4
     - name: Install dependencies

--- a/django/.env.example
+++ b/django/.env.example
@@ -43,8 +43,8 @@ VECTORDB_PGBOUNCER=False
 
 AZURE_STORAGE_ACCOUNT_NAME=jussandboxottostorage
 AZURE_STORAGE_CONTAINER=otto
-AZURE_KEYVAULT_URL=https://jus-sandbox-otto-kv.vault.azure.net/
-AZURE_OPENAI_ENDPOINT=https://jus-sandbox-otto-openai-canadaeast.openai.azure.com/
+AZURE_KEYVAULT_URL=https://jus-sandbox-loc-kv.vault.azure.net/
+AZURE_OPENAI_ENDPOINT=https://oai-otto-sandbox.openai.azure.com/
 AZURE_OPENAI_VERSION=2025-03-01-preview
 AZURE_COGNITIVE_SERVICE_ENDPOINT=https://canadacentral.api.cognitive.microsoft.com
 AZURE_COGNITIVE_SERVICE_REGION="canadacentral"

--- a/django/chat/responses.py
+++ b/django/chat/responses.py
@@ -11,7 +11,6 @@ from django.utils.translation import gettext as _
 
 from asgiref.sync import sync_to_async
 from data_fetcher.util import get_request
-from llama_index.core.llms import ChatMessage, MessageRole
 from llama_index.core.vector_stores.types import MetadataFilter, MetadataFilters
 from rules.contrib.views import objectgetter
 from structlog import get_logger
@@ -19,9 +18,9 @@ from structlog.contextvars import bind_contextvars
 
 from chat.llm import OttoLLM
 from chat.models import Message
-from chat.prompts import current_time_prompt
 from chat.tasks import translate_file
 from chat.utils import (
+    chat_to_history,
     combine_batch_generators,
     combine_response_generators,
     combine_response_replacers,
@@ -30,7 +29,6 @@ from chat.utils import (
     get_source_titles,
     group_sources_into_docs,
     htmx_stream,
-    is_text_to_summarize,
     num_tokens_from_string,
     sort_by_max_score,
     stream_to_replacer,
@@ -44,9 +42,8 @@ from otto.utils.decorators import permission_required
 
 logger = get_logger(__name__)
 
-batch_size = (
-    5  # Maximum number of simultaneous LLM queries for multiple docs, sources, etc.
-)
+# Maximum number of simultaneous LLM queries for multiple docs, sources, etc.
+batch_size = 5
 
 
 @permission_required("chat.access_message", objectgetter(Message, "message_id"))
@@ -135,29 +132,11 @@ def chat_response(
     response_message,
     switch_mode=False,
 ):
-
-    system_prompt = current_time_prompt() + chat.options.chat_system_prompt
-    chat_history = [ChatMessage(role=MessageRole.SYSTEM, content=system_prompt)]
-    chat_history += [
-        ChatMessage(
-            role=MessageRole.ASSISTANT if message.is_bot else MessageRole.USER,
-            content=(
-                message.text
-                if not is_text_to_summarize(message)
-                else "<text to summarize...>"
-            ),
-        )
-        for message in chat.messages.all().order_by("date_created")
-    ]
-
-    if chat_history[-1].role == MessageRole.ASSISTANT and not chat_history[-1].content:
-        # The last message is likely an empty placeholder - remove it to avoid errors
-        chat_history.pop()
-
     model = chat.options.chat_model
     temperature = chat.options.chat_temperature
-
     llm = OttoLLM(model, temperature)
+
+    chat_history = chat_to_history(chat)
 
     tokens = num_tokens_from_string(
         " ".join(message.content or "" for message in chat_history)

--- a/django/locale/translation/translations.json
+++ b/django/locale/translation/translations.json
@@ -3850,5 +3850,21 @@
     "Outputs from Otto may contain the intellectual property of others, including excerpts of copyrighted material and third-party trademarks. Users intending to include outputs from Otto in external publications or communications should review the output carefully. The Treasury Board guidance referred to below provides helpful recommendations in this respect. Avoid using Otto-generated content in government publications when it is particularly critical that the Crown own the copyright.": {
         "fr": "",
         "fr_auto": "Les résultats d’Otto peuvent contenir la propriété intellectuelle d’autrui, y compris des extraits de matériel protégé par le droit d’auteur et des marques de commerce de tiers. Les utilisateurs qui ont l’intention d’inclure des extrants d’Otto dans des publications ou des communications externes doivent examiner attentivement les extrants. Les directives du Conseil du Trésor mentionnées ci-dessous contiennent des recommandations utiles à cet égard. Évitez d’utiliser du contenu généré par Otto dans des publications gouvernementales lorsqu’il est particulièrement important que la Couronne détienne les droits d’auteur."
+    },
+    "Bot responded with these files: ": {
+        "fr": "",
+        "fr_auto": "Bot a répondu avec ces fichiers : "
+    },
+    "User uploaded these files: ": {
+        "fr": "",
+        "fr_auto": "L’utilisateur a téléchargé ces fichiers : "
+    },
+    "(empty message)": {
+        "fr": "",
+        "fr_auto": "(message vide)"
+    },
+    "<text to summarize...>": {
+        "fr": "",
+        "fr_auto": "<texte pour résumer...>"
     }
 }

--- a/django/otto/management/commands/reset_app_data.py
+++ b/django/otto/management/commands/reset_app_data.py
@@ -70,7 +70,7 @@ class Command(BaseCommand):
             self.reset_groups()
             self.reset_apps()
             self.reset_security_labels()
-            self.reset_libraries()
+            self.reset_libraries("library_mini.yaml")
             self.reset_cost_types()
             self.reset_presets()
         else:


### PR DESCRIPTION
Addresses some issues I encountered when deploying Sandbox, but applies to the main branch as well.
* update endpoints in .env.example
* handle models that only work with a single prompt
* fill empty messages in chat history (e.g. with filenames uploaded by user or created by bot)
* make chat/utils.py "copy_options" robust to use from within management commands (for loading preset fixtures)
* update "reset_app_data --all" management command to load the library_mini.yaml