### PR TITLE
fix: restore library creation/saving

### DIFF
--- a/django/librarian/templates/librarian/components/edit_details.html
+++ b/django/librarian/templates/librarian/components/edit_details.html
@@ -4,7 +4,7 @@
 <div id="librarian-details" {% if swap %}hx-swap-oob="true"{% endif %}>
   {% include "components/messages.html" %}
 
-  {% if selected_library.id %}
+  {% if selected_library.id or selected_library.temp %}
     {% has_perm 'librarian.edit_library' user selected_library as can_edit_library %}
     {% if can_edit_library %}
       {% if detail_form %}

--- a/django/librarian/views.py
+++ b/django/librarian/views.py
@@ -231,7 +231,7 @@ def modal_view(request, item_type=None, item_id=None, parent_id=None):
                     users_form = LibraryUsersForm(library=selected_library)
             elif not selected_library:
                 new_library = create_temp_object("library")
-                libraries.insert(0, new_library)
+                editable_libraries.insert(0, new_library)
                 selected_library = new_library
                 focus_el = "#id_name_en"
             form = form or LibraryDetailForm(

--- a/django/otto/rules.py
+++ b/django/otto/rules.py
@@ -201,6 +201,8 @@ def can_view_library(user, library):
 
 @predicate
 def can_edit_library(user, library):
+    if getattr(library, "temp", False):
+        return True
     if library.is_public:
         if is_admin(user):
             return True


### PR DESCRIPTION
The PR that separated editable libraries and viewable libraries made it impossible to save a newly-created library, since the temporary new library wouldn't be given the necessary editing permissions. This PR fixes that.