### PR TITLE
fix: laws schedules details page not working

### DIFF
--- a/django/laws/views.py
+++ b/django/laws/views.py
@@ -493,7 +493,11 @@ def search(request):
 def sources_to_html(sources):
     return [
         {
-            "node_id": urllib.parse.quote_plus(s.node.node_id).replace("+", "-"),
+            "node_id": (
+                urllib.parse.quote_plus(s.node.node_id)
+                if "_schedule_" in s.node.node_id
+                else urllib.parse.quote_plus(s.node.node_id).replace("+", "-")
+            ),
             "title": s.node.metadata["display_metadata"].split("\n")[0],
             "chunk": (
                 s.node.metadata["chunk"]


### PR DESCRIPTION
 - issue with details page not working due to some characters in node_id being replaced with entirely different ones.
 - node_id: urllib.parse.quote_plus(s.node.node_id).replace("+", "-") was causing the issue
 - solution was to check if node_id contains "_schedule_" and not make any replacements if it does