### PR TITLE
feat: Add URL Parameter Support for Tool Selection in Agent Mode

### DIFF
--- a/django/chat/urls.py
+++ b/django/chat/urls.py
@@ -10,6 +10,7 @@ app_name = "chat"
 urlpatterns = [
     path("", views.new_chat, name="new_chat"),
     path("chat-with-ai/", views.new_chat_with_ai, name="chat_with_ai"),
+    path("agent/", views.new_agent, name="new_agent"),
     path("summarize/", views.new_summarize, name="summarize"),
     path("translate/", views.new_translate, name="translate"),
     path("qa/", views.new_qa, name="qa"),

--- a/django/chat/views.py
+++ b/django/chat/views.py
@@ -82,7 +82,7 @@ def new_agent(request):
     # 1  Create the Chat in agent mode
     chat = Chat.objects.create(user=request.user, mode="agent")
 
-    # 2  Parse ?tools=…  (default = empty list → no tools enabled)
+    # 2  Parse ?tools=…  (default = empty list → all tools enabled)
     tool_keys = request.GET.get("tools", "")
     tool_keys = [t.strip().lower() for t in tool_keys.split(",") if t.strip()]
 

--- a/django/chat/views.py
+++ b/django/chat/views.py
@@ -23,6 +23,7 @@ from rules.contrib.views import objectgetter
 from structlog import get_logger
 from structlog.contextvars import bind_contextvars
 
+from chat.agent.tools.tool_registry import AVAILABLE_TOOLS
 from chat.forms import ChatOptionsForm, ChatRenameForm, PresetForm, UploadForm
 from chat.llm import OttoLLM
 from chat.models import (
@@ -69,6 +70,35 @@ new_translate = lambda request: new_chat(request, mode="translate")
 new_summarize = lambda request: new_chat(request, mode="summarize")
 new_document_qa = lambda request: new_chat(request, mode="document_qa")
 new_qa = lambda request: new_chat(request, mode="qa")
+
+
+@app_access_required(app_name)
+def new_agent(request):
+    """
+    Creates a new Chat in Agent mode.
+    Optional query-param ?tools=<tool_key>[,<tool_key>...] pre-selects allowed tools.
+    Example: /agent?tools=law_retriever
+    """
+    # 1  Create the Chat in agent mode
+    chat = Chat.objects.create(user=request.user, mode="agent")
+
+    # 2  Parse ?tools=…  (default = empty list → no tools enabled)
+    tool_keys = request.GET.get("tools", "")
+    tool_keys = [t.strip().lower() for t in tool_keys.split(",") if t.strip()]
+
+    # 3  Filter only VALID tools (security!)
+    valid_tools = [k for k in tool_keys if k in AVAILABLE_TOOLS]
+
+    # If user provided none or only invalid, enable all by default
+    if not valid_tools:
+        valid_tools = list(AVAILABLE_TOOLS.keys())  # enable all tools
+
+    # 4  Persist into ChatOptions
+    chat.options.agent_tools = valid_tools  # e.g. ["law_retriever"]
+    chat.options.save()
+
+    # 5  Redirect to normal chat URL so SPA loads as usual
+    return redirect("chat:chat", chat_id=chat.id)
 
 
 @app_access_required(app_name)

--- a/django/locale/translation/translations.json
+++ b/django/locale/translation/translations.json
@@ -4446,5 +4446,13 @@
     "Enabled tools": {
         "fr": "",
         "fr_auto": "Outils activés"
+    },
+    "Hide outputs": {
+        "fr": "",
+        "fr_auto": "Masquer les sorties"
+    },
+    "Show outputs": {
+        "fr": "",
+        "fr_auto": "Afficher les extrants"
     }
 }


### PR DESCRIPTION
This pull request adds support for selecting agent tools using URL parameters in the existing agent chat mode. The main goal is to make it possible to launch a tailored chat experience—for example, starting a session that only uses data from Justipedia.

Our long-term plan is to place an "Ask Otto" button inside Justipedia. When a user clicks this button, the chat will open in agent mode with only the Justipedia tool enabled. In the future, this tool will know how to interact directly with Justipedia’s content, just like we currently do with Wikipedia. This provides a seamless, focused experience in which Otto can answer questions using trusted content from Justipedia only. This flexible mechanism also sets the stage for easy integration with other sites and data sources.

Changes in this PR:
- You can now add a `?tools=` parameter to an agent chat URL. The system will enable only the specified agent tools in that chat session.
- If the URL does not specify tools, or the provided tool names are invalid, the chat will use all available tools by default.
- The selected tools are stored in the chat options, and users are redirected to the regular chat UI.
- Additional tests were added to cover different ways of specifying the `tools` parameter, including blank or invalid input.

This update makes it easier to launch customized agent chat sessions from external sites or applications. It paves the way for future, deeply integrated "Ask Otto" experiences, starting with Justipedia. The changes are backward compatible and only affect agent mode sessions started by URL parameter.