### PR TITLE
fix: bug for saving default presets for the first time

### DIFF
--- a/django/chat/templates/chat/modals/presets/presets_form.html
+++ b/django/chat/templates/chat/modals/presets/presets_form.html
@@ -102,7 +102,7 @@
              name="make_default"
              value="True"
              title="{% trans 'Set as default' %}">
-      {% if request.user.default_preset.id|stringformat:"s" == preset_id|stringformat:"s" %}
+      {% if request.user.default_preset and preset_id and request.user.default_preset.id|stringformat:"s" == preset_id|stringformat:"s" %}
         <p class="mt-3 mb-0 pb-0" style="font-style:italic">
           {% trans "This is your default preset for new chats. To change your default preset, return to the Browse Presets page and click the 'star' for a different preset." %}
         </p>


### PR DESCRIPTION
The Jinja condition {% if request.user.default_preset.id|stringformat:"s" == preset_id|stringformat:"s" %} is creating a scenario where we are performing the operation '' == '' which returns True, when it should be returning False since both variables are empty.

This is because request.user.default_preset is set to None due to the reset_app_data presets call, and then calling .id on None makes Django templates return an empty string instead of throwing an AttributeError. In the case of preset_id, it is not defined since we never pass it, and somehow Django's stringformat filter converts this to an empty string value also. We can test this in the django shell with the script:

from django.template import Template, Context
none_var=None
template_string = "{{x.id|stringformat:'s'}}"
template = Template(template_string)
context = Context({'x':none_var})
result1 = template.render(context)

template_string = "{{ preset_id|stringformat:'s' }}"
template = Template(template_string)
context = Context({})  # No preset_id defined
result2 = template.render(context)
print(f"Result 1: '{result1}'")
print(f"Result 2:  '{result2}'")
print(f"result1 == result2: '{result1==result2}'")