### PR TITLE
fix: break formatting in markdown render

### DIFF
--- a/django/chat/static/chat/js/scripts.js
+++ b/django/chat/static/chat/js/scripts.js
@@ -50,7 +50,7 @@ function render_markdown(element) {
     }
     const parent = markdown_text.parentElement;
     if (to_parse) {
-      parent.innerHTML = md.render(to_parse);
+      parent.innerHTML = md.render(to_parse).replaceAll('&lt;br&gt;', '<br>');
       const current_dots = parent.parentElement.querySelector(".typing");
       // If dots=True on htmx_stream call and we just removed the dots at the beginning of stream,
       // add a new dots element after parent


### PR DESCRIPTION
<br> elements in data-md attribute of chat messages now render properly, enabling, e.g., line breaks within table cells