### PR TITLE
feat: redirect to subsection when viewing law sources

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -106,6 +106,18 @@
             "justMyCode": false
         },
         {
+            "name": "Django: Load Laws",
+            "type": "debugpy",
+            "request": "launch",
+            "program": "${workspaceFolder}/django/manage.py",
+            "args": [
+                "load_laws_xml",
+                "--small",
+            ],
+            "django": true,
+            "justMyCode": false
+        },
+        {
             "name": "Python: Current File",
             "type": "debugpy",
             "request": "launch",

--- a/django/laws/templates/laws/source_details.html
+++ b/django/laws/templates/laws/source_details.html
@@ -28,7 +28,9 @@
                 data-text="{{ source_node.text }}">{% trans "Find similar sections" %}</button>
       </div>
       <div class="col-auto">
-        <a href="{{ law.url }}" class="text-decoration-none p-0" target="_blank">{% trans "Go to source document" %} <i class="bi bi-box-arrow-up-right"></i></a>
+        <a href="{{ law.url }}{{ url_suffix }}"
+           class="text-decoration-none p-0"
+           target="_blank">{% trans "Go to source document" %} <i class="bi bi-box-arrow-up-right"></i></a>
       </div>
     </div>
     <h5 class="card-title border-bottom pb-2 h6">{% trans "Metadata" %}</h5>

--- a/django/laws/views.py
+++ b/django/laws/views.py
@@ -71,7 +71,7 @@ def index(request):
 
 def source(request, source_id):
     source_id = urllib.parse.unquote_plus(source_id)
-    source_node = get_source_node(source_id)
+    source_node = get_source_node(source_id.replace("Constitution-", "Constitution "))
     # What language is the source_node?
     lang = "eng" if "eng" in source_node["metadata"]["doc_id"] else "fra"
     if lang == "eng":
@@ -92,10 +92,13 @@ def source(request, source_id):
             else None
         )
     law.url = get_law_url(law, lang)
+
+    url_suffix = f"{'FullText' if lang=='eng' else 'TexteComplet'}.html#{source_node['metadata']['lims_id']}"
     context = {
         "source_node": source_node,
         "other_lang_node": other_lang_node,
         "law": law,
+        "url_suffix": url_suffix,
     }
     if not source_node:
         return HttpResponse(_("Source not found."), status=404)


### PR DESCRIPTION
In response to user feedback, have the "Go to source document" links in Legislation Search sources scroll down automatically to the relevant (sub)section, using the lims-id's which correspond to element id's in the HTML.