### PR TITLE
fix: access "data source status" as library viewer

### DIFF
--- a/django/librarian/views.py
+++ b/django/librarian/views.py
@@ -316,7 +316,7 @@ def modal_view(request, item_type=None, item_id=None, parent_id=None):
 
 
 @permission_required(
-    "librarian.edit_data_source", objectgetter(DataSource, "data_source_id")
+    "librarian.view_data_source", objectgetter(DataSource, "data_source_id")
 )
 def poll_status(request, data_source_id, document_id=None):
     """


### PR DESCRIPTION
https://dev.azure.com/BusinessAnalyticsCentre/BAC%20Agile/_workitems/edit/3320

Polling view now requires library viewing permission, not editing permission. Viewers will no longer get booted with an "unauthorized access" notification when viewing a document's status during processing.