### PR TITLE
fix: full file path not visible to non-RAG Q&A modes

### DIFF
--- a/django/chat/responses.py
+++ b/django/chat/responses.py
@@ -258,8 +258,10 @@ def summarize_response(chat, response_message):
                                         and hasattr(failed_file, "filename")
                                         else ""
                                     )
-                                    error_str = _(
-                                        f"Error extracting text from file{file_label}."
+                                    error_str = (
+                                        _("Error extracting text from file")
+                                        + file_label
+                                        + "."
                                     )
                                     error_str += f" _({_('Error ID:')} {error_id})_"
                                     error_files.append((error_str, failed_file))

--- a/django/locale/translation/translations.json
+++ b/django/locale/translation/translations.json
@@ -4771,9 +4771,9 @@
         "fr": "",
         "fr_auto": "Extraire du texte de fichiers..."
     },
-    "Error extracting text from file.": {
+    "Error extracting text from file": {
         "fr": "",
-        "fr_auto": "Erreur lors de l’extraction du texte du fichier."
+        "fr_auto": "Erreur lors de l’extraction du texte du fichier"
     },
     "Extracting text from files": {
         "fr": "",
@@ -4894,9 +4894,5 @@
     "Remove banner": {
         "fr": "",
         "fr_auto": "Supprimer la bannière"
-    },
-    "Error extracting text from file{file_label}.": {
-        "fr": "",
-        "fr_auto": "Erreur lors de l’extraction du texte de file{file_label}."
     }
 }


### PR DESCRIPTION
Couldn't see what was nested in full document mode for files extracted from emails or zip content.

Fixed by adding document file path to context of full document mode.