### PR TITLE
fix: close tag on form HTML

### DIFF
--- a/django/chat/forms.py
+++ b/django/chat/forms.py
@@ -316,7 +316,7 @@ class ChatOptionsForm(ModelForm):
                         """
                         <strong>Combine:</strong> Read all selected documents together, write single answer. <em>Essential for comparing documents. Usually less detailed.</em>
                         <br><br>
-                        <strong>Separate:</strong> Read each selected document individually and write a separate answer for each. <em>Usually more detailed. Expensive./em>
+                        <strong>Separate:</strong> Read each selected document individually and write a separate answer for each. <em>Usually more detailed. Expensive.</em>
                         """
                     ),
                 },

--- a/django/locale/translation/translations.json
+++ b/django/locale/translation/translations.json
@@ -4894,5 +4894,9 @@
     "Remove banner": {
         "fr": "",
         "fr_auto": "Supprimer la bannière"
+    },
+    "\n                        <strong>Combine:</strong> Read all selected documents together, write single answer. <em>Essential for comparing documents. Usually less detailed.</em>\n                        <br><br>\n                        <strong>Separate:</strong> Read each selected document individually and write a separate answer for each. <em>Usually more detailed. Expensive.</em>\n                        ": {
+        "fr": "",
+        "fr_auto": "\n<strong>Combiner :</strong> Lisez tous les documents sélectionnés ensemble, rédigez une seule réponse. <em>Essentiel pour comparer des documents. Généralement moins détaillé.</em>\n                        <br><br>\n                        <strong>Séparer :</strong> Lisez chaque document sélectionné individuellement et rédigez une réponse distincte pour chacun. <em>Généralement plus détaillé. Coûteux.</em>\n                        "
     }
 }


### PR DESCRIPTION
An HTML tag in the hover text for "Combined/Separate" was mistyped. Fixed now. 