### PR TITLE
fix: preview banner now works when message_en and/or message_fr not present

### DIFF
--- a/django/otto/views.py
+++ b/django/otto/views.py
@@ -1265,6 +1265,20 @@ def manage_banner(request):
             category = request.POST.get("category")
             timeout_hours = int(request.POST.get("timeout_hours", 24))
             timeout = timeout_hours * 3600
+            if request.POST.get("preview"):
+                message = (
+                    message_fr
+                    if getattr(request, "LANGUAGE_CODE", "en") == "fr"
+                    else message_en
+                )
+                return render(
+                    request,
+                    "components/message_from_admins.html",
+                    {
+                        "message_from_admins": message,
+                        "message_from_admins_category": category,
+                    },
+                )
             if message_en and message_fr:
                 banner = {
                     "message_en": message_en,
@@ -1272,20 +1286,6 @@ def manage_banner(request):
                     "category": category,
                     "timeout": timeout,
                 }
-                if request.POST.get("preview"):
-                    message = (
-                        "message_fr"
-                        if getattr(request, "LANGUAGE_CODE", "en") == "fr"
-                        else "message_en"
-                    )
-                    return render(
-                        request,
-                        "components/message_from_admins.html",
-                        {
-                            "message_from_admins": banner[message],
-                            "message_from_admins_category": category,
-                        },
-                    )
                 cache.set(
                     "message_from_admins",
                     banner,

--- a/django/tests/otto/test_otto_views.py
+++ b/django/tests/otto/test_otto_views.py
@@ -146,14 +146,24 @@ def test_manage_banner(client, all_apps_user):
     user = all_apps_user()
     client.force_login(user)
 
+    # Test preview with just an English message
     response = client.post(
         reverse("manage_banner"),
         data={"message_en": "Hello there", "preview": "true", "category": "info"},
     )
-
     assert response.status_code == 200
-
     assert (
         '<div id="message-from-admins" class="info">Hello there</div>'
+        in response.content.decode()
+    )
+
+    # Test banner creation
+    response = client.post(
+        reverse("manage_banner"),
+        data={"message_en": "Hello", "message_fr": "Bonjour", "category": "warning"},
+    )
+    assert response.status_code == 200
+    assert (
+        '<div id="message-from-admins" class="danger">Hello</div>'
         in response.content.decode()
     )

--- a/django/tests/otto/test_otto_views.py
+++ b/django/tests/otto/test_otto_views.py
@@ -160,7 +160,7 @@ def test_manage_banner(client, all_apps_user):
     # Test banner creation
     response = client.post(
         reverse("manage_banner"),
-        data={"message_en": "Hello", "message_fr": "Bonjour", "category": "warning"},
+        data={"message_en": "Hello", "message_fr": "Bonjour", "category": "danger"},
     )
     assert response.status_code == 200
     assert (

--- a/django/tests/otto/test_otto_views.py
+++ b/django/tests/otto/test_otto_views.py
@@ -139,3 +139,21 @@ def test_initialize_feedback_for_chat_mode(client, all_apps_user):
     form.initialize_chat_feedback(message.id)
 
     assert form.fields["app"].initial == "translate"
+
+
+@pytest.mark.django_db
+def test_manage_banner(client, all_apps_user):
+    user = all_apps_user()
+    client.force_login(user)
+
+    response = client.post(
+        reverse("manage_banner"),
+        data={"message_en": "Hello there", "preview": "true", "category": "info"},
+    )
+
+    assert response.status_code == 200
+
+    assert (
+        '<div id="message-from-admins" class="info">Hello there</div>'
+        in response.content.decode()
+    )


### PR DESCRIPTION
Previous logic for banner management did not properly direct the preview button unless both message_en and message_fr were present, leading to a bad HTMX request (page redundantly displayed within itself). Moving the preview button logic outside of the message check allows it to work reasonably in all circumstances.