### PR TITLE
fix: show French-only names for Libraries and folders in English

### DIFF
--- a/django/otto/settings.py
+++ b/django/otto/settings.py
@@ -353,6 +353,8 @@ LOCALE_PATHS = [
     os.path.join(BASE_DIR, "locale"),
 ]
 
+MODELTRANSLATION_FALLBACK_LANGUAGES = ("en", "fr")
+
 USE_TZ = True
 
 PROJECT_ROOT = os.path.dirname(os.path.abspath(__file__))


### PR DESCRIPTION
https://dev.azure.com/BusinessAnalyticsCentre/BAC%20Agile/_boards/board/t/Otto/Projects?workitem=3333