### PR TITLE
fix: display time in user's timezone

### DIFF
--- a/django/otto/settings.py
+++ b/django/otto/settings.py
@@ -193,6 +193,7 @@ MIDDLEWARE = [
     "azure_auth.middleware.AzureMiddleware",
     "otto.utils.auth.AcceptTermsMiddleware",
     "django.middleware.locale.LocaleMiddleware",
+    "otto.utils.middleware.TimezoneMiddleware",
     "data_fetcher.middleware.GlobalRequestMiddleware",
     "django.middleware.common.CommonMiddleware",
     "django.middleware.csrf.CsrfViewMiddleware",

--- a/django/otto/templates/base.html
+++ b/django/otto/templates/base.html
@@ -5,6 +5,14 @@
 <html lang="{{ LANGUAGE_CODE }}">
 
   <head>
+    <script>
+      // Set timezone cookie and reload before rendering if not set
+      if (!document.cookie.includes('otto-timezone')) {
+        var tz = Intl.DateTimeFormat().resolvedOptions().timeZone;
+        document.cookie = "otto-timezone=" + tz + ";path=/";
+        location.reload();
+      }
+    </script>
     <!-- Required meta tags -->
     <meta charset="utf-8" />
     <meta name="viewport"

--- a/django/otto/utils/middleware.py
+++ b/django/otto/utils/middleware.py
@@ -1,4 +1,5 @@
 from importlib import import_module
+from zoneinfo import ZoneInfo
 
 from django.conf import settings
 from django.contrib.messages import get_messages
@@ -82,3 +83,18 @@ class PreventConcurrentLoginsMiddleware(MiddlewareMixin):
                     request.user.visitor.save()
             else:
                 Visitor.objects.create(user=request.user, session_key=key_from_cookie)
+
+
+class TimezoneMiddleware(MiddlewareMixin):
+    def process_request(self, request):
+        if request.user.is_authenticated:
+            tzname = request.COOKIES.get("otto-timezone")
+            if tzname:
+                try:
+                    timezone.activate(ZoneInfo(tzname))
+                    return
+                except Exception:
+                    timezone.deactivate()
+            else:
+                timezone.deactivate()
+        return self.get_response(request)


### PR DESCRIPTION
Times should be displayed in the user's timezone. Data is still stored in UTC

<img width="341" height="116" alt="image" src="https://github.com/user-attachments/assets/fb3d7f53-6681-4cfd-b62f-b642e1b13ff0" />

_instead of 16:26_