### PR TITLE
fix: disable async usage in OttoLLM to address bug 3344

### DIFF
--- a/django/chat/llm.py
+++ b/django/chat/llm.py
@@ -318,7 +318,7 @@ class OttoLLM:
             similarity_top_k=top_k,
             num_queries=1,  # set this to 1 to disable query generation
             mode="relative_score",
-            use_async=True,
+            # use_async=True, # See bug 3344
             retriever_weights=[vector_weight, 1 - vector_weight],
             llm=self.llm,
         )
@@ -392,7 +392,7 @@ class OttoLLM:
             summary_template=summary_template,
             output_cls=None,
             streaming=True,
-            use_async=True,
+            # use_async=True, # See bug 3344
             verbose=True,
         )
 


### PR DESCRIPTION
Application was experiencing ConnectionDoesNotExistError during vector database queries, particularly on first requests to new models. The error occurred when asyncpg connections were closed mid-operation during JSON codec setup, likely due to event loop handling issues in threaded environments combined with the recent switch from transaction to session pooling (bug #3344).

- Disabled use_async=True in both get_retriever() and _get_tree_summarizer() functions
- Resolves immediate connection stability issues
- Performance impact expected to be minimal for current workloads
- Allows continued operation while investigating proper async/pooling configuration
- Re-enable async mode once root cause is addressed