### PR TITLE
feat: split embedding model demand between questions and documents

### DIFF
--- a/django/chat/llm.py
+++ b/django/chat/llm.py
@@ -95,9 +95,6 @@ class OttoLLM:
     "model" must match the name of the LLM deployment in Azure.
     """
 
-    # Since the questions deployment has less quota, use it by default for embeddings
-    # Document processing must be explicitly configured, which is appropriate since it's a specialized use case
-
     def __init__(
         self,
         deployment: str = settings.DEFAULT_CHAT_MODEL,

--- a/django/laws/tasks.py
+++ b/django/laws/tasks.py
@@ -353,7 +353,10 @@ def process_law_status(law_status, laws_root, mock_embedding, debug, current_tas
         # Update law status to "processing"
         law_status.save()
 
-        llm = OttoLLM(mock_embedding=mock_embedding)
+        llm = OttoLLM(
+            mock_embedding=mock_embedding,
+            embedding_deployment="text-embedding-3-large-documents",
+        )
         document_en = None
         document_fr = None
         nodes_en = None

--- a/django/librarian/tasks.py
+++ b/django/librarian/tasks.py
@@ -50,7 +50,10 @@ def process_document(
     document.celery_task_id = current_task.request.id
     document.save()
 
-    llm = OttoLLM(mock_embedding=mock_embedding)
+    llm = OttoLLM(
+        mock_embedding=mock_embedding,
+        embedding_deployment="text-embedding-3-large-documents",
+    )
     try:
         with translation.override(language):
             process_document_helper(document, llm, pdf_method)


### PR DESCRIPTION
This pull request updates our Azure OpenAI embedding deployment and application code to prevent heavy document processing from rate limiting the embedding service needed by users who are asking chat questions.

**What Was Changed**

Infrastructure:
- The Terraform now creates two deployments of the text-embedding-3-large OpenAI model:
  - One for user/questions (text-embedding-3-large-questions)
  - One for batch document ingestion (text-embedding-3-large-documents)
- The OpenAI quota (tokens-per-minute) is split between these two:
  - A percentage is reserved for chat questions (user requests)
  - The remainder is reserved for background document processing

Django Code:
- The OttoLLM embedding wrapper now accepts an embedding_deployment parameter.
- All code paths that handle user chat or Q&A are switched to use the "questions" deployment.
- All librarian/document-ingest code paths now use the "documents" deployment.
- The default embedding deployment in code is now the "questions" model, to favour real-time user responsiveness.

**Why This Was Done**
- When both chat and bulk document processing use the same embedding model deployment, a surge of ingestion jobs (like big uploads or library batch jobs) could exhaust the model’s rate limit. This would cause regular users' chat questions to be slowed down or even blocked.
- By splitting the quota at the Azure deployment layer and routing workloads to different deployments, we ensure that:
  - Day-to-day user chat and Q&A remains fast and responsive.
  - Background document processing cannot "starve" the interactive experiences, even under heavy ingestion load.